### PR TITLE
fix(ci): fix unit-test linkage and MockMqttClient signature

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -78,6 +78,6 @@ build_flags =
     -DINSOMNIATV_NATIVE
     -std=c++17
     -ggdb
-    -fprofile-arcs
-    -ftest-coverage
+    --coverage
+    -lgcov
 test_build_src = true

--- a/test/test_hal/test_hal_mocks.cpp
+++ b/test/test_hal/test_hal_mocks.cpp
@@ -87,7 +87,8 @@ public:
   }
   void disconnect() override { connected_ = false; }
   bool isConnected() const override { return connected_; }
-  int16_t publish(const String&, const String&, uint8_t, bool) override {
+  int16_t publish(const String&, const String&, uint8_t qos = 0,
+                  bool retain = false) override {
     publishCount_++;
     return 1;
   }


### PR DESCRIPTION
Resolves #10. Fixed linker errors by using --coverage and -lgcov. Fixed MockMqttClient signature mismatch.