### PR TITLE
feat(network): implement WiFi setup portal and reset button logic

### DIFF
--- a/docs/architecture-diagram.md
+++ b/docs/architecture-diagram.md
@@ -15,8 +15,10 @@ graph TD
 
     %% System Core
     EB -->|Publish| SSM[SystemStateManager]
+    WS[WifiSetup] -->|Init WiFi| EB
 
     %% State Logic
+
     SSM -->|Update State| S[SystemState]
     S -->|Subscribe/React| FSM[SleepStateMachine]
     FSM -->|Schedule/Ramp| RS[RampScheduler]

--- a/platformio.ini
+++ b/platformio.ini
@@ -42,6 +42,7 @@ lib_deps =
   ESP32Async/ESpAsyncWebServer @ 3.11.0
   bblanchon/ArduinoJson @ ^7.0.4
   marian-craciunescu/ESP32Ping @ ^1.7
+  https://github.com/tzapu/WiFiManager.git
 custom_component_remove =
     espressif/esp_hosted
     espressif/esp_wifi_remote

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,11 +13,13 @@
 #include <string>
 
 #include "config/ConfigManager.h"
+#include "network/WifiSetup.h"
 
 // Onboard LED (active-low) for nologo C3 super mini
 #define STATUS_LED_PIN 8
 
 static InsomniaTV::ConfigManager configMgr;
+static InsomniaTV::WifiSetup wifiSetup;
 static Ticker heartbeat;
 
 void toggleStatusLed() {
@@ -54,12 +56,16 @@ void setup() {
   }
 
   Serial.println("[insomniaTV] Initialization complete");
+
+  // WiFi Setup
+  wifiSetup.begin();
 }
 
 void loop() {
+  wifiSetup.handleResetButton();
   // Phase 1: minimal loop
   // Later phases will add task scheduling here
-  delay(1000);
+  delay(100);
 }
 
 #endif  // UNIT_TEST

--- a/src/network/WifiSetup.cpp
+++ b/src/network/WifiSetup.cpp
@@ -1,0 +1,78 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#include "WifiSetup.h"
+
+#include <cstdio>
+#include <string>
+
+#if defined(ARDUINO)
+#include <WiFi.h>
+#include <WiFiManager.h>
+#endif
+
+namespace InsomniaTV {
+
+#if defined(ARDUINO)
+// GPIO 9 is the BOOT button on most C3 modules
+static const int RESET_BUTTON_PIN = 9;
+#endif
+
+WifiSetup::WifiSetup() : _buttonPressStart(0), _isButtonPressed(false) {}
+
+void WifiSetup::begin() {
+#if defined(ARDUINO)
+  WiFiManager wm;
+
+  std::string apName = "insomnia-" + getChipId();
+
+  // Attempt to connect or start AP
+  if (!wm.autoConnect(apName.c_str())) {
+    Serial.println("[insomniaTV] WiFi connection failed and portal timed out");
+    ESP.restart();
+  }
+
+  Serial.println("[insomniaTV] WiFi connected");
+  Serial.print("[insomniaTV] IP address: ");
+  Serial.println(WiFi.localIP());
+
+  pinMode(RESET_BUTTON_PIN, INPUT_PULLUP);
+#endif
+}
+
+void WifiSetup::handleResetButton() {
+#if defined(ARDUINO)
+  // Active low button
+  bool currentVal = (digitalRead(RESET_BUTTON_PIN) == LOW);
+
+  if (currentVal && !_isButtonPressed) {
+    _isButtonPressed = true;
+    _buttonPressStart = millis();
+    Serial.println("[insomniaTV] Reset button pressed...");
+  } else if (!currentVal && _isButtonPressed) {
+    _isButtonPressed = false;
+    _buttonPressStart = 0;
+  }
+
+  if (_isButtonPressed && (millis() - _buttonPressStart > 10000)) {
+    Serial.println(
+        "[insomniaTV] Reset button held for 10s! Clearing WiFi settings...");
+    WiFiManager wm;
+    wm.resetSettings();
+    ESP.restart();
+  }
+#endif
+}
+
+std::string WifiSetup::getChipId() {
+#if defined(ARDUINO)
+  uint64_t chipid = ESP.getEfuseMac();
+  char idStr[13];
+  snprintf(idStr, sizeof(idStr), "%04X%08X",
+           static_cast<uint16_t>(chipid >> 32), static_cast<uint32_t>(chipid));
+  return std::string(idStr);
+#else
+  return "NATIVE_CHIP";
+#endif
+}
+
+}  // namespace InsomniaTV

--- a/src/network/WifiSetup.h
+++ b/src/network/WifiSetup.h
@@ -1,0 +1,37 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#ifndef SRC_NETWORK_WIFISETUP_H_
+#define SRC_NETWORK_WIFISETUP_H_
+
+#include <stdint.h>
+
+#include <string>
+
+namespace InsomniaTV {
+
+/**
+ * @brief Manages WiFi configuration and initial setup portal.
+ */
+class WifiSetup {
+public:
+  WifiSetup();
+
+  /**
+   * @brief Initializes WiFi connection or starts AP portal if not configured.
+   */
+  void begin();
+
+  /**
+   * @brief Checks if reset button is held for 10 seconds and resets WiFi if so.
+   */
+  void handleResetButton();
+
+private:
+  std::string getChipId();
+  uint32_t _buttonPressStart;
+  bool _isButtonPressed;
+};
+
+}  // namespace InsomniaTV
+
+#endif  // SRC_NETWORK_WIFISETUP_H_

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -17,10 +17,23 @@ void WebServer::begin() {
 
 void WebServer::setupRoutes() {
   _server.on("/api/status", HTTP_GET, [](AsyncWebServerRequest* request) {
+    if (!request->authenticate("admin", "insomnia")) {
+      return request->requestAuthentication();
+    }
     // Placeholder JSON response
     request->send(200, "application/json", "{\"status\":\"ok\"}");
   });
+
+  _server.on("/wifi", HTTP_GET, [](AsyncWebServerRequest* request) {
+    if (!request->authenticate("admin", "insomnia")) {
+      return request->requestAuthentication();
+    }
+    request->send(200, "text/html",
+                  "<h1>WiFi Configuration</h1><p>Placeholder for WiFi setup. "
+                  "Use physical button (10s) to reset.</p>");
+  });
 }
+
 #else
 WebServer::WebServer(uint16_t port) {}
 void WebServer::begin() {}

--- a/test/test_wifi/test_wifi.cpp
+++ b/test/test_wifi/test_wifi.cpp
@@ -1,0 +1,19 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#include <unity.h>
+
+#include "../../src/network/WifiSetup.h"
+
+using InsomniaTV::WifiSetup;
+
+void test_wifi_setup_init() {
+  WifiSetup ws;
+  // Basic instantiation test
+  TEST_ASSERT_TRUE(true);
+}
+
+int main() {
+  UNITY_BEGIN();
+  RUN_TEST(test_wifi_setup_init);
+  return UNITY_END();
+}


### PR DESCRIPTION
Implements WiFi configuration portal and physical reset button logic as per Issue #30.

- Uses WiFiManager for initial AP portal (insomnia-CHIPID).
- Configures connection to user WiFi.
- Adds basic authentication to WebServer (admin:insomnia).
- Implements 10s button hold to reset WiFi settings.
- Updates documentation and architecture diagram.

Closes #30