### PR TITLE
feat(sensors+tv): sensor framework, TvStateMachine with sensor fusion, SleepStateMachine wiring

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,21 +2,20 @@ name: Auto Format
 
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        description: Branch to format
-        required: false
-        default: ''
+  push:
+    branches:
+      - 'feature/**'
 
 jobs:
   format:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install clang-format

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,41 @@
+name: Auto Format
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch to format
+        required: false
+        default: ''
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install clang-format
+        run: pip install clang-format==22.1.5
+
+      - name: Apply clang-format
+        run: |
+          find src test -name '*.cpp' -o -name '*.h' | \
+            xargs clang-format --style=file -i
+
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email \
+            "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No formatting changes needed."
+          else
+            git commit -m "style: auto-apply clang-format"
+            git push
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ managed_components/
 
 # Build logs
 *.log
+
+# Generated version header (rebuilt each compile)
+src/version.h

--- a/docs/SENSORS.md
+++ b/docs/SENSORS.md
@@ -1,0 +1,39 @@
+# Sensor Framework
+
+The insomniaTV Sensor Framework provides a unified, extensible way to aggregate readings from various hardware and software sources.
+
+## Core Components
+
+### `Sensor` Base Class
+All sensors must inherit from the `Sensor` abstract base class.
+
+```cpp
+class Sensor {
+public:
+    virtual String getId() const = 0;
+    virtual String getType() const = 0;
+    virtual bool read() = 0;
+    virtual JsonDocument getConfig() = 0;
+    virtual void setConfig(const JsonDocument& cfg) = 0;
+    virtual bool isAvailable() const;
+    virtual ~Sensor() = default;
+};
+```
+
+### `SensorManager`
+A singleton registry that manages sensor instances and provides thread-safe access.
+
+## Adding New Sensors
+
+1. Create a new class in `src/sensors/` that inherits from `Sensor`.
+2. Implement all required virtual methods.
+3. Register your sensor in `SensorManager`.
+4. Add any required UI templates for configuration.
+
+## Built-in Sensors
+
+- **GPIO Input**: Digital input with debounce.
+- **GPIO Analog**: ADC reading with scaling.
+- **Ping**: Network reachability check.
+- **HTTP**: Remote service status check.
+- **UPnP**: Device discovery and monitoring.

--- a/huge_app.csv
+++ b/huge_app.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     ,        0x4000,
+otadata,  data, ota,     ,        0x2000,
+phy_init, data, phy,     ,        0x1000,
+ota_0,    app,  ota_0,   ,        0x180000,
+ota_1,    app,  ota_1,   ,        0x180000,
+storage,  data, spiffs,  ,        0xD9000,

--- a/platformio.ini
+++ b/platformio.ini
@@ -120,9 +120,9 @@ lib_deps =
 build_flags =
     ${env.build_flags}
     -DARDUINO_ARCH_ESP32
-board_build.partitions = min_spiffs.csv
-upload_port = /dev/ttyACM0
-monitor_port = /dev/ttyACM0
+board_build.partitions = huge_app.csv
+upload_protocol = espota
+upload_port = insomnia-<CHIPID>.local
 test_framework = ${env.test_framework}
 test_ignore = test_*
 
@@ -143,5 +143,6 @@ lib_deps =
 build_flags =
     ${env.build_flags}
     -DARDUINO_ARCH_ESP32
-board_build.partitions = min_spiffs.csv
+    -DBOARD_HAS_PSRAM
+board_build.partitions = huge_app.csv
 test_framework = ${env.test_framework}

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,14 +11,11 @@ description = The cure for watching TV when you should be sleeping
 [env]
 framework = arduino
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
-#platform_packages = tool-esptoolpy @ https://github.com/pioarduino/esptool/releases/download/v4.8.11/esptool.zip
 build_flags =
   -Og
   -Wall -Wextra
   -Wno-unused-parameter
   -D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_VERBOSE
-  ; -D CONFIG_ASYNC_TCP_MAX_ACK_TIME=5000
-  ; -D CONFIG_ASYNC_TCP_PRIORITY=10
   -D CONFIG_ASYNC_TCP_QUEUE_SIZE=128
   -D CONFIG_ASYNC_TCP_RUNNING_CORE=1
   -D CONFIG_ASYNC_TCP_STACK_SIZE=8192
@@ -28,9 +25,6 @@ build_flags =
   -I${platformio.packages_dir}/framework-arduinoespressif32/libraries/Network/src
   -I${platformio.packages_dir}/framework-arduinoespressif32/libraries/FS/src
   -I${platformio.packages_dir}/framework-arduinoespressif32/libraries/WiFi/src
-#  -Wall
-#  -Wextra
-#  -Wno-unused-parameter
 upload_protocol = esptool
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder, log2file
@@ -58,11 +52,10 @@ custom_component_remove =
     espressif/rmaker_common
 
 custom_sdkconfig = CONFIG_LWIP_MAX_ACTIVE_TCP=32
-
 test_framework = unity
 
 ; ---------------------------------------------------------------------------
-; Native environment for unit testing (requires platform-native)
+; Native environment for unit testing
 ; ---------------------------------------------------------------------------
 [env:native]
 platform = native
@@ -77,7 +70,6 @@ build_flags =
     -std=c++11
     --coverage
     -lgcov
-
 lib_deps =
     arduino-mock@^0.2.0
     unity@^1.12.1
@@ -107,19 +99,22 @@ test_ignore = test_*
 
 monitor_filters =
     esp32_exception_decoder
-    time      ; Add timestamp with milliseconds for each new line
+    time
 
 ; ---------------------------------------------------------------------------
-; ESP32-DevKit-C (standard ESP32) for compatibility testing
+; ESP32-C3 OTA firmware target
 ; ---------------------------------------------------------------------------
-[env:esp32dev]
-board = esp32dev
+[env:esp32c3-ota]
+board = esp32-c3-devkitm-1
 framework = arduino
 lib_deps =
     ${env.lib_deps}
 build_flags =
     ${env.build_flags}
     -DARDUINO_ARCH_ESP32
+    -DARDUINO_USB_MODE=1
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -D IDF_CCACHE_ENABLE=1
 board_build.partitions = huge_app.csv
 upload_protocol = espota
 upload_port = insomnia-<CHIPID>.local
@@ -131,9 +126,28 @@ monitor_filters =
     time
 
 ; ---------------------------------------------------------------------------
-; QEMU ESP32 emulator for unit testing without hardware
-; Note: pioarduino platform doesn't support qemu-esp32 board
-; Use esp32dev instead for cross-compilation testing
+; ESP32-DevKit-C (standard ESP32)
+; ---------------------------------------------------------------------------
+[env:esp32dev]
+board = esp32dev
+framework = arduino
+lib_deps =
+    ${env.lib_deps}
+build_flags =
+    ${env.build_flags}
+    -DARDUINO_ARCH_ESP32
+board_build.partitions = huge_app.csv
+upload_port = /dev/ttyACM0
+monitor_port = /dev/ttyACM0
+test_framework = ${env.test_framework}
+test_ignore = test_*
+
+monitor_filters =
+    esp32_exception_decoder
+    time
+
+; ---------------------------------------------------------------------------
+; QEMU ESP32 emulator
 ; ---------------------------------------------------------------------------
 [env:qemu-esp32]
 board = esp32dev

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,7 @@ description = The cure for watching TV when you should be sleeping
 [env]
 framework = arduino
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
+extra_scripts = pre:scripts/version_helper.py
 build_flags =
   -Og
   -Wall -Wextra
@@ -19,7 +20,6 @@ build_flags =
   -D CONFIG_ASYNC_TCP_QUEUE_SIZE=128
   -D CONFIG_ASYNC_TCP_RUNNING_CORE=1
   -D CONFIG_ASYNC_TCP_STACK_SIZE=8192
-  -D INSOMNIATV_VERSION=\"0.1.0-dev\"
   -I${platformio.packages_dir}/framework-arduinoespressif32/cores/esp32
   -I${platformio.packages_dir}/framework-arduinoespressif32/libraries
   -I${platformio.packages_dir}/framework-arduinoespressif32/libraries/Network/src

--- a/scripts/version_helper.py
+++ b/scripts/version_helper.py
@@ -19,4 +19,10 @@ with open("data/version.txt", "w") as f:
     f.write(revision)
 
 Import("env")
-env.Append(CPPDEFINES=[("INSOMNIATV_VERSION", f'\\"{revision}\\"')])
+# Write a generated header instead of injecting via CPPDEFINES.
+# CPPDEFINES changes the compiler invocation for every translation unit,
+# causing ccache to miss on all of them whenever the git hash changes.
+# A generated header limits recompilation to files that include it.
+version_header = os.path.join("src", "version.h")
+with open(version_header, "w") as f:
+    f.write(f'#pragma once\n#define INSOMNIATV_VERSION "{revision}"\n')

--- a/scripts/version_helper.py
+++ b/scripts/version_helper.py
@@ -7,7 +7,16 @@ def get_git_revision_short_hash():
     except:
         return 'unknown'
 
+def is_git_dirty():
+    try:
+        subprocess.check_output(['git', 'diff', '--quiet', 'HEAD'], stderr=subprocess.DEVNULL)
+        return False
+    except subprocess.CalledProcessError:
+        return True
+
 revision = get_git_revision_short_hash()
+if is_git_dirty():
+    revision += '-dev'
 print(f"Build Version: {revision}")
 
 # Create data directory if it doesn't exist

--- a/scripts/version_helper.py
+++ b/scripts/version_helper.py
@@ -1,4 +1,5 @@
 import subprocess
+import os
 
 def get_git_revision_short_hash():
     try:
@@ -9,7 +10,14 @@ def get_git_revision_short_hash():
 revision = get_git_revision_short_hash()
 print(f"Build Version: {revision}")
 
+# Create data directory if it doesn't exist
+if not os.path.exists("data"):
+    os.makedirs("data")
+
+# Write version to data/version.txt for filesystem upload
+with open("data/version.txt", "w") as f:
+    f.write(revision)
+
 Import("env")
-env.Append(CPPDEFINES=[
-    ("INSOMNIATV_VERSION", f'\\"{revision}\\"')
-])
+# We no longer append to CPPDEFINES to avoid breaking the build cache
+# env.Append(CPPDEFINES=[("INSOMNIATV_VERSION", f'\\"{revision}\\"')])

--- a/scripts/version_helper.py
+++ b/scripts/version_helper.py
@@ -19,5 +19,4 @@ with open("data/version.txt", "w") as f:
     f.write(revision)
 
 Import("env")
-# We no longer append to CPPDEFINES to avoid breaking the build cache
-# env.Append(CPPDEFINES=[("INSOMNIATV_VERSION", f'\\"{revision}\\"')])
+env.Append(CPPDEFINES=[("INSOMNIATV_VERSION", f'\\"{revision}\\"')])

--- a/scripts/version_helper.py
+++ b/scripts/version_helper.py
@@ -1,0 +1,15 @@
+import subprocess
+
+def get_git_revision_short_hash():
+    try:
+        return subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
+    except:
+        return 'unknown'
+
+revision = get_git_revision_short_hash()
+print(f"Build Version: {revision}")
+
+Import("env")
+env.Append(CPPDEFINES=[
+    ("INSOMNIATV_VERSION", f'\\"{revision}\\"')
+])

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1,7 +1,9 @@
 // Copyright 2026 insomniaTV Contributors. All rights reserved.
 
 #include "config/ConfigManager.h"
+
 #include <ArduinoJson.h>
+
 #include <string>
 
 #if defined(ARDUINO)
@@ -25,7 +27,8 @@ ConfigStatus ConfigManager::load() {
   }
 
   File file = LittleFS.open(kConfigPath, "r");
-  if (!file) return ConfigStatus::FileNotFound;
+  if (!file)
+    return ConfigStatus::FileNotFound;
 
   std::string json = file.readString().c_str();
   file.close();
@@ -48,10 +51,11 @@ ConfigStatus ConfigManager::save() {
 #if defined(ARDUINO)
   // Ensure directory exists
   if (!LittleFS.exists("/config")) {
-      LittleFS.mkdir("/config");
+    LittleFS.mkdir("/config");
   }
   File file = LittleFS.open(kConfigPath, "w");
-  if (!file) return ConfigStatus::WriteFailed;
+  if (!file)
+    return ConfigStatus::WriteFailed;
   file.print(json.c_str());
   file.close();
   return ConfigStatus::Ok;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -103,6 +103,10 @@ bool ConfigManager::validate(const Config& cfg, std::string& outError) {
     outError = "tv_verify retries must be between 1 and 5";
     return false;
   }
+  if (cfg.tvVerifyMethod != "ping" && cfg.tvVerifyMethod != "http") {
+    outError = "tv_verify method must be 'ping' or 'http'";
+    return false;
+  }
   return true;
 }
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1,10 +1,12 @@
 // Copyright 2026 insomniaTV Contributors. All rights reserved.
 
 #include "config/ConfigManager.h"
-
 #include <ArduinoJson.h>
-
 #include <string>
+
+#if defined(ARDUINO)
+#include <LittleFS.h>
+#endif
 
 namespace InsomniaTV {
 
@@ -16,18 +18,47 @@ ConfigManager::ConfigManager() {
 }
 
 ConfigStatus ConfigManager::load() {
-  // Phase 1: placeholder for FS -- filesystem integration in Phase 5
-  // For now, just ensuring it returns Ok with defaults.
+#if defined(ARDUINO)
+  if (!LittleFS.exists(kConfigPath)) {
+    applyDefaults_();
+    return ConfigStatus::FileNotFound;
+  }
+
+  File file = LittleFS.open(kConfigPath, "r");
+  if (!file) return ConfigStatus::FileNotFound;
+
+  std::string json = file.readString().c_str();
+  file.close();
+
+  Config next;
+  if (!parseJson_(json, next)) {
+    return ConfigStatus::InvalidJson;
+  }
+
+  current_ = next;
+  return ConfigStatus::Ok;
+#else
   applyDefaults_();
   return ConfigStatus::Ok;
+#endif
 }
 
 ConfigStatus ConfigManager::save() {
-  // Phase 1: placeholder for FS -- filesystem integration in Phase 5
-  // We can still call toJson_ to ensure it's functional.
   std::string json = toJson_(current_);
+#if defined(ARDUINO)
+  // Ensure directory exists
+  if (!LittleFS.exists("/config")) {
+      LittleFS.mkdir("/config");
+  }
+  File file = LittleFS.open(kConfigPath, "w");
+  if (!file) return ConfigStatus::WriteFailed;
+  file.print(json.c_str());
+  file.close();
+  return ConfigStatus::Ok;
+#else
   (void)json;
   return ConfigStatus::Ok;
+#endif
 }
 
 const Config& ConfigManager::get() const {
@@ -70,10 +101,6 @@ bool ConfigManager::validate(const Config& cfg, std::string& outError) {
   }
   if (cfg.tvVerifyRetries < 1 || cfg.tvVerifyRetries > 5) {
     outError = "tv_verify retries must be between 1 and 5";
-    return false;
-  }
-  if (cfg.tvVerifyMethod != "ping" && cfg.tvVerifyMethod != "http") {
-    outError = "tv_verify method must be 'ping' or 'http'";
     return false;
   }
   return true;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -108,6 +108,7 @@ void ConfigManager::resetToDefaults() {
   d.irLearnedCodesPath = "/ir_learned.json";
   d.webPort = 80;
   d.webAuthEnabled = false;
+  d.sensorsJson = "[]";
   current_ = d;
 }
 
@@ -170,6 +171,10 @@ bool ConfigManager::parseJson_(const std::string& json, Config& out) {
     out.webAuthEnabled = doc["web"]["auth_enabled"] | false;
   }
 
+  if (doc["sensors"].is<JsonArray>()) {
+    serializeJson(doc["sensors"], out.sensorsJson);
+  }
+
   return true;
 }
 
@@ -218,6 +223,12 @@ std::string ConfigManager::toJson_(const Config& cfg) {
   JsonObject web = doc["web"].to<JsonObject>();
   web["port"] = cfg.webPort;
   web["auth_enabled"] = cfg.webAuthEnabled;
+
+  if (!cfg.sensorsJson.empty()) {
+    JsonDocument sensorDoc;
+    deserializeJson(sensorDoc, cfg.sensorsJson);
+    doc["sensors"] = sensorDoc.as<JsonArray>();
+  }
 
   std::string out;
   serializeJson(doc, out);

--- a/src/config/ConfigManager.h
+++ b/src/config/ConfigManager.h
@@ -63,6 +63,9 @@ struct Config {
   // Web
   uint16_t webPort;
   bool webAuthEnabled;
+
+  // Sensors
+  std::string sensorsJson;
 };
 
 // Config change notification callback

--- a/src/discovery/SamsungTvDiscovery.cpp
+++ b/src/discovery/SamsungTvDiscovery.cpp
@@ -91,38 +91,36 @@ void SamsungTvDiscovery::parseSsdpResponse(const std::string& response) {
 
   std::string location = response.substr(locPos + 10, endPos - (locPos + 10));
 
-  // Check if we already have this location
-  bool exists = false;
+  // Extract IP from location URL before the duplicate check
+  std::string ip;
+  size_t ipStart = location.find("//");
+  if (ipStart != std::string::npos) {
+    size_t ipEnd = location.find(":", ipStart + 2);
+    if (ipEnd == std::string::npos)
+      ipEnd = location.find("/", ipStart + 2);
+    if (ipEnd != std::string::npos)
+      ip = location.substr(ipStart + 2, ipEnd - (ipStart + 2));
+  }
+
+  // Deduplicate by IP — a TV may respond multiple times (one per service)
   {
     std::lock_guard<std::mutex> lock(_mutex);
     auto it = std::find_if(_discoveredTvs.begin(), _discoveredTvs.end(),
-                           [&location](const SamsungTvInfo& info) {
-                             return info.location == location;
+                           [&ip](const SamsungTvInfo& info) {
+                             return !ip.empty() && info.ip == ip;
                            });
     if (it != _discoveredTvs.end())
-      exists = true;
+      return;
   }
 
-  if (!exists) {
-    SamsungTvInfo newTv;
-    newTv.location = location;
+  SamsungTvInfo newTv;
+  newTv.location = location;
+  newTv.ip = ip;
 
-    // Extract IP from location
-    size_t ipStart = location.find("//");
-    if (ipStart != std::string::npos) {
-      size_t ipEnd = location.find(":", ipStart + 2);
-      if (ipEnd == std::string::npos)
-        ipEnd = location.find("/", ipStart + 2);
-      if (ipEnd != std::string::npos) {
-        newTv.ip = location.substr(ipStart + 2, ipEnd - (ipStart + 2));
-      }
-    }
-
-    fetchDeviceMetadata(newTv);
-    if (!newTv.name.empty()) {
-      std::lock_guard<std::mutex> lock(_mutex);
-      _discoveredTvs.push_back(newTv);
-    }
+  fetchDeviceMetadata(newTv);
+  if (!newTv.name.empty()) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    _discoveredTvs.push_back(newTv);
   }
 }
 

--- a/src/hal/HallSensor.h
+++ b/src/hal/HallSensor.h
@@ -12,15 +12,15 @@ namespace InsomniaTV {
  */
 class HallSensor : public IHallSensor {
 public:
-    explicit HallSensor(uint8_t pin);
-    ~HallSensor() override = default;
+  explicit HallSensor(uint8_t pin);
+  ~HallSensor() override = default;
 
-    float getCurrentAmperes() override;
-    void calibrate() override;
+  float getCurrentAmperes() override;
+  void calibrate() override;
 
 private:
-    uint8_t _pin;
-    float _zeroPoint;
+  uint8_t _pin;
+  float _zeroPoint;
 };
 
 }  // namespace InsomniaTV

--- a/src/hal/IFileSystem.h
+++ b/src/hal/IFileSystem.h
@@ -7,6 +7,7 @@
 #include <Arduino.h>
 #endif
 
+#include <cstdint>
 #include <string>
 
 namespace InsomniaTV {

--- a/src/hal/IHallSensor.h
+++ b/src/hal/IHallSensor.h
@@ -12,18 +12,18 @@ namespace InsomniaTV {
  */
 class IHallSensor {
 public:
-    virtual ~IHallSensor() = default;
+  virtual ~IHallSensor() = default;
 
-    /**
-     * @brief Gets the current reading in Amperes.
-     * @return Current in Amperes, or -1.0 on failure.
-     */
-    virtual float getCurrentAmperes() = 0;
+  /**
+   * @brief Gets the current reading in Amperes.
+   * @return Current in Amperes, or -1.0 on failure.
+   */
+  virtual float getCurrentAmperes() = 0;
 
-    /**
-     * @brief Calibrates the sensor zero-point.
-     */
-    virtual void calibrate() = 0;
+  /**
+   * @brief Calibrates the sensor zero-point.
+   */
+  virtual void calibrate() = 0;
 };
 
 }  // namespace InsomniaTV

--- a/src/hal/IMqttClient.h
+++ b/src/hal/IMqttClient.h
@@ -7,9 +7,9 @@
 #include <Arduino.h>
 #endif
 
+#include <cstdint>
 #include <functional>
 #include <string>
-#include <cstdint>
 
 namespace InsomniaTV {
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include "config/ConfigManager.h"
 #include "discovery/SamsungTvDiscovery.h"
 #include "network/WifiSetup.h"
+#include "sensors/SensorManager.h"
 #include "web/WebServer.h"
 
 // Onboard LED (active-low) for nologo C3 super mini
@@ -63,6 +64,11 @@ void setup() {
 
   // WiFi Setup
   wifiSetup.begin();
+
+  // Sensor Framework
+  Serial.println("[insomniaTV] Initializing sensor framework...");
+  InsomniaTV::SensorManager::instance().init(
+      configMgr.get().sensorsJson.c_str(), tvDiscovery);
 
   // Web Server
   webServer.begin();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@
 static InsomniaTV::ConfigManager configMgr;
 static InsomniaTV::WifiSetup wifiSetup;
 static InsomniaTV::SamsungTvDiscovery tvDiscovery;
-static InsomniaTV::WebServer webServer(80, tvDiscovery);
+static InsomniaTV::WebServer webServer(80, tvDiscovery, configMgr);
 static Ticker heartbeat;
 
 void toggleStatusLed() {

--- a/src/mqtt/MqttBridge.h
+++ b/src/mqtt/MqttBridge.h
@@ -16,17 +16,18 @@ namespace InsomniaTV {
  */
 class MqttBridge {
 public:
-    /**
-     * @brief Constructs MqttBridge.
-     * @param client The MQTT client HAL interface.
-     * @param ssm The system state manager to observe.
-     */
-    MqttBridge(IMqttClient& client, const SystemStateManager& ssm);
+  /**
+   * @brief Constructs MqttBridge.
+   * @param client The MQTT client HAL interface.
+   * @param ssm The system state manager to observe.
+   */
+  MqttBridge(IMqttClient& client, const SystemStateManager& ssm);
 
-    /**
-     * @brief Serializes the current system state and publishes it to MQTT.
-     */
-    void publishStatus();
+  /**
+   * @brief Serializes the current system state and publishes it to MQTT.
+   */
+  void publishStatus();
+
 private:
   IMqttClient& _client;
   const SystemStateManager& _ssm;

--- a/src/network/NetworkChecker.h
+++ b/src/network/NetworkChecker.h
@@ -4,6 +4,7 @@
 #define SRC_NETWORK_NETWORKCHECKER_H_
 
 #include <string>
+
 #include "../hal/INetworkChecker.h"
 
 namespace InsomniaTV {
@@ -16,39 +17,39 @@ namespace InsomniaTV {
  */
 class NetworkChecker : public INetworkChecker {
 public:
-    /**
-     * @brief Constructs the NetworkChecker.
-     */
-    NetworkChecker() = default;
-    ~NetworkChecker() override = default;
+  /**
+   * @brief Constructs the NetworkChecker.
+   */
+  NetworkChecker() = default;
+  ~NetworkChecker() override = default;
 
-    /**
-     * @brief Pings the target IP address.
-     * @param ip The target IP address as a string.
-     * @return RTT in ms if successful, -1 otherwise.
-     */
-    int32_t ping(const std::string& ip) override;
+  /**
+   * @brief Pings the target IP address.
+   * @param ip The target IP address as a string.
+   * @return RTT in ms if successful, -1 otherwise.
+   */
+  int32_t ping(const std::string& ip) override;
 
-    /**
-     * @brief Performs an HTTP GET request to the given URL.
-     * @param url The target URL.
-     * @return HTTP status code if successful, -1 otherwise.
-     */
-    int32_t httpGet(const std::string& url) override;
+  /**
+   * @brief Performs an HTTP GET request to the given URL.
+   * @param url The target URL.
+   * @return HTTP status code if successful, -1 otherwise.
+   */
+  int32_t httpGet(const std::string& url) override;
 
-    /**
-     * @brief Sets the timeout for network operations.
-     * @param timeoutMs Timeout duration in milliseconds.
-     */
-    void setTimeout(uint32_t timeoutMs) override;
+  /**
+   * @brief Sets the timeout for network operations.
+   * @param timeoutMs Timeout duration in milliseconds.
+   */
+  void setTimeout(uint32_t timeoutMs) override;
 
-    /**
-     * @brief Checks if the WiFi interface is currently connected.
-     */
-    bool isConnected() const override;
+  /**
+   * @brief Checks if the WiFi interface is currently connected.
+   */
+  bool isConnected() const override;
 
 private:
-    uint32_t _timeoutMs = 1000;
+  uint32_t _timeoutMs = 1000;
 };
 
 }  // namespace InsomniaTV

--- a/src/network/WifiSetup.cpp
+++ b/src/network/WifiSetup.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #if defined(ARDUINO)
+#include <ArduinoOTA.h>
 #include <WiFi.h>
 #include <WiFiManager.h>
 #endif
@@ -35,12 +36,17 @@ void WifiSetup::begin() {
   Serial.print("[insomniaTV] IP address: ");
   Serial.println(WiFi.localIP());
 
+  ArduinoOTA.setHostname(apName.c_str());
+  ArduinoOTA.onStart([]() { Serial.println("OTA Start"); });
+  ArduinoOTA.begin();
+
   pinMode(RESET_BUTTON_PIN, INPUT_PULLUP);
 #endif
 }
 
 void WifiSetup::handleResetButton() {
 #if defined(ARDUINO)
+  ArduinoOTA.handle();
   // Active low button
   bool currentVal = (digitalRead(RESET_BUTTON_PIN) == LOW);
 
@@ -67,8 +73,9 @@ std::string WifiSetup::getChipId() {
 #if defined(ARDUINO)
   uint64_t chipid = ESP.getEfuseMac();
   char idStr[13];
-  snprintf(idStr, sizeof(idStr), "%04X%08X",
+  snprintf(idStr, sizeof(idStr), "%04X%08lX",
            static_cast<uint16_t>(chipid >> 32), static_cast<uint32_t>(chipid));
+
   return std::string(idStr);
 #else
   return "NATIVE_CHIP";

--- a/src/sensors/GpioAnalogSensor.cpp
+++ b/src/sensors/GpioAnalogSensor.cpp
@@ -1,0 +1,59 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#include "GpioAnalogSensor.h"
+
+#include <memory>
+#include <string>
+
+#if defined(ARDUINO)
+#include <Arduino.h>
+#endif
+
+namespace InsomniaTV {
+
+GpioAnalogSensor::GpioAnalogSensor(const std::string& id, uint8_t pin)
+    : id_(id), pin_(pin), lastValue_(0.0f), scale_(1.0f), offset_(0.0f) {}
+
+std::shared_ptr<Sensor> GpioAnalogSensor::create(const JsonDocument& cfg) {
+  std::string id = cfg["id"] | "";
+  uint8_t pin = cfg["pin"] | 0;
+  if (id == "")
+    return nullptr;
+  auto sensor = std::make_shared<GpioAnalogSensor>(id, pin);
+  sensor->setConfig(cfg);
+  return sensor;
+}
+
+bool GpioAnalogSensor::read() {
+#if defined(ARDUINO)
+  int raw = analogRead(pin_);
+  lastValue_ = (static_cast<float>(raw) * scale_) + offset_;
+  return true;
+#else
+  return false;
+#endif
+}
+
+JsonDocument GpioAnalogSensor::getConfig() {
+  JsonDocument doc;
+  doc["id"] = id_;
+  doc["type"] = "gpio_analog";
+  doc["pin"] = pin_;
+  doc["scale"] = scale_;
+  doc["offset"] = offset_;
+  return doc;
+}
+
+void GpioAnalogSensor::setConfig(const JsonDocument& cfg) {
+  if (cfg["pin"].is<uint8_t>()) {
+    pin_ = cfg["pin"];
+  }
+  if (cfg["scale"].is<float>()) {
+    scale_ = cfg["scale"];
+  }
+  if (cfg["offset"].is<float>()) {
+    offset_ = cfg["offset"];
+  }
+}
+
+}  // namespace InsomniaTV

--- a/src/sensors/GpioAnalogSensor.h
+++ b/src/sensors/GpioAnalogSensor.h
@@ -1,0 +1,36 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#ifndef SRC_SENSORS_GPIOANALOGSENSOR_H_
+#define SRC_SENSORS_GPIOANALOGSENSOR_H_
+
+#include <memory>
+#include <string>
+
+#include "Sensor.h"
+
+namespace InsomniaTV {
+
+class GpioAnalogSensor : public Sensor {
+public:
+  GpioAnalogSensor(const std::string& id, uint8_t pin);
+  static std::shared_ptr<Sensor> create(const JsonDocument& cfg);
+
+  std::string getId() const override { return id_; }
+  std::string getType() const override { return "gpio_analog"; }
+  bool read() override;
+  JsonDocument getConfig() override;
+  void setConfig(const JsonDocument& cfg) override;
+
+  float getValue() const { return lastValue_; }
+
+private:
+  std::string id_;
+  uint8_t pin_;
+  float lastValue_;
+  float scale_;
+  float offset_;
+};
+
+}  // namespace InsomniaTV
+
+#endif  // SRC_SENSORS_GPIOANALOGSENSOR_H_

--- a/src/sensors/GpioInputSensor.cpp
+++ b/src/sensors/GpioInputSensor.cpp
@@ -1,0 +1,74 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#include "GpioInputSensor.h"
+
+#include <memory>
+#include <string>
+
+namespace InsomniaTV {
+
+GpioInputSensor::GpioInputSensor(const std::string& id, uint8_t pin,
+                                 bool pullup)
+    : id_(id),
+      pin_(pin),
+      pullup_(pullup),
+      lastState_(false),
+      lastDebounceTime_(0),
+      debounceDelay_(50) {
+#if defined(ARDUINO)
+  pinMode(pin_, pullup_ ? INPUT_PULLUP : INPUT);
+#endif
+}
+
+std::shared_ptr<Sensor> GpioInputSensor::create(const JsonDocument& cfg) {
+  std::string id = cfg["id"] | "";
+  uint8_t pin = cfg["pin"] | 0;
+  bool pullup = cfg["pullup"] | true;
+  if (id == "")
+    return nullptr;
+  auto sensor = std::make_shared<GpioInputSensor>(id, pin, pullup);
+  sensor->setConfig(cfg);
+  return sensor;
+}
+
+bool GpioInputSensor::read() {
+#if defined(ARDUINO)
+  bool reading = (digitalRead(pin_) == (pullup_ ? LOW : HIGH));
+
+  if (reading != lastState_) {
+    lastDebounceTime_ = millis();
+  }
+
+  if ((millis() - lastDebounceTime_) > debounceDelay_) {
+    lastState_ = reading;
+  }
+#endif
+  return lastState_;
+}
+
+JsonDocument GpioInputSensor::getConfig() {
+  JsonDocument doc;
+  doc["id"] = id_;
+  doc["type"] = "gpio_input";
+  doc["pin"] = pin_;
+  doc["pullup"] = pullup_;
+  doc["debounce_ms"] = debounceDelay_;
+  return doc;
+}
+
+void GpioInputSensor::setConfig(const JsonDocument& cfg) {
+  if (cfg["pin"].is<uint8_t>()) {
+    pin_ = cfg["pin"];
+  }
+  if (cfg["pullup"].is<bool>()) {
+    pullup_ = cfg["pullup"];
+  }
+  if (cfg["debounce_ms"].is<uint32_t>()) {
+    debounceDelay_ = cfg["debounce_ms"];
+  }
+#if defined(ARDUINO)
+  pinMode(pin_, pullup_ ? INPUT_PULLUP : INPUT);
+#endif
+}
+
+}  // namespace InsomniaTV

--- a/src/sensors/GpioInputSensor.h
+++ b/src/sensors/GpioInputSensor.h
@@ -1,0 +1,39 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#ifndef SRC_SENSORS_GPIOINPUTSENSOR_H_
+#define SRC_SENSORS_GPIOINPUTSENSOR_H_
+
+#include <memory>
+#include <string>
+
+#include "Sensor.h"
+
+#if defined(ARDUINO)
+#include <Arduino.h>
+#endif
+
+namespace InsomniaTV {
+
+class GpioInputSensor : public Sensor {
+public:
+  GpioInputSensor(const std::string& id, uint8_t pin, bool pullup = true);
+  static std::shared_ptr<Sensor> create(const JsonDocument& cfg);
+
+  std::string getId() const override { return id_; }
+  std::string getType() const override { return "gpio_input"; }
+  bool read() override;
+  JsonDocument getConfig() override;
+  void setConfig(const JsonDocument& cfg) override;
+
+private:
+  std::string id_;
+  uint8_t pin_;
+  bool pullup_;
+  bool lastState_;
+  uint32_t lastDebounceTime_;
+  uint32_t debounceDelay_;
+};
+
+}  // namespace InsomniaTV
+
+#endif  // SRC_SENSORS_GPIOINPUTSENSOR_H_

--- a/src/sensors/HttpSensor.cpp
+++ b/src/sensors/HttpSensor.cpp
@@ -1,0 +1,58 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#include "HttpSensor.h"
+
+#include <memory>
+#include <string>
+
+#if defined(ARDUINO)
+#include <HTTPClient.h>
+#endif
+
+namespace InsomniaTV {
+
+HttpSensor::HttpSensor(const std::string& id, const std::string& url)
+    : id_(id), url_(url), lastCode_(-1), timeoutMs_(5000) {}
+
+std::shared_ptr<Sensor> HttpSensor::create(const JsonDocument& cfg) {
+  std::string id = cfg["id"] | "";
+  std::string url = cfg["url"] | "";
+  if (id == "")
+    return nullptr;
+  auto sensor = std::make_shared<HttpSensor>(id, url);
+  sensor->setConfig(cfg);
+  return sensor;
+}
+
+bool HttpSensor::read() {
+#if defined(ARDUINO)
+  HTTPClient http;
+  http.begin(url_.c_str());
+  http.setTimeout(timeoutMs_);
+  lastCode_ = http.GET();
+  http.end();
+  return lastCode_ > 0;
+#else
+  return false;
+#endif
+}
+
+JsonDocument HttpSensor::getConfig() {
+  JsonDocument doc;
+  doc["id"] = id_;
+  doc["type"] = "http";
+  doc["url"] = url_;
+  doc["timeout_ms"] = timeoutMs_;
+  return doc;
+}
+
+void HttpSensor::setConfig(const JsonDocument& cfg) {
+  if (cfg["url"].is<std::string>()) {
+    url_ = cfg["url"].as<std::string>();
+  }
+  if (cfg["timeout_ms"].is<uint32_t>()) {
+    timeoutMs_ = cfg["timeout_ms"];
+  }
+}
+
+}  // namespace InsomniaTV

--- a/src/sensors/HttpSensor.h
+++ b/src/sensors/HttpSensor.h
@@ -1,0 +1,36 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#ifndef SRC_SENSORS_HTTPSENSOR_H_
+#define SRC_SENSORS_HTTPSENSOR_H_
+
+#include <memory>
+#include <string>
+
+#include "Sensor.h"
+
+namespace InsomniaTV {
+
+class HttpSensor : public Sensor {
+public:
+  HttpSensor(const std::string& id, const std::string& url);
+  static std::shared_ptr<Sensor> create(const JsonDocument& cfg);
+
+  std::string getId() const override { return id_; }
+  std::string getType() const override { return "http"; }
+  bool read() override;
+  JsonDocument getConfig() override;
+  void setConfig(const JsonDocument& cfg) override;
+  bool isAvailable() const override { return lastCode_ > 0; }
+
+  int getLastCode() const { return lastCode_; }
+
+private:
+  std::string id_;
+  std::string url_;
+  int lastCode_;
+  uint32_t timeoutMs_;
+};
+
+}  // namespace InsomniaTV
+
+#endif  // SRC_SENSORS_HTTPSENSOR_H_

--- a/src/sensors/PingSensor.cpp
+++ b/src/sensors/PingSensor.cpp
@@ -1,0 +1,54 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#include "PingSensor.h"
+
+#include <memory>
+#include <string>
+
+#if defined(ARDUINO)
+#include <ESP32Ping.h>
+#endif
+
+namespace InsomniaTV {
+
+PingSensor::PingSensor(const std::string& id, const std::string& targetIp)
+    : id_(id), targetIp_(targetIp), lastResult_(false), timeoutMs_(1000) {}
+
+std::shared_ptr<Sensor> PingSensor::create(const JsonDocument& cfg) {
+  std::string id = cfg["id"] | "";
+  std::string targetIp = cfg["target_ip"] | "";
+  if (id == "")
+    return nullptr;
+  auto sensor = std::make_shared<PingSensor>(id, targetIp);
+  sensor->setConfig(cfg);
+  return sensor;
+}
+
+bool PingSensor::read() {
+#if defined(ARDUINO)
+  lastResult_ = Ping.ping(targetIp_.c_str(), 1);
+#else
+  lastResult_ = false;
+#endif
+  return lastResult_;
+}
+
+JsonDocument PingSensor::getConfig() {
+  JsonDocument doc;
+  doc["id"] = id_;
+  doc["type"] = "ping";
+  doc["target_ip"] = targetIp_;
+  doc["timeout_ms"] = timeoutMs_;
+  return doc;
+}
+
+void PingSensor::setConfig(const JsonDocument& cfg) {
+  if (cfg["target_ip"].is<std::string>()) {
+    targetIp_ = cfg["target_ip"].as<std::string>();
+  }
+  if (cfg["timeout_ms"].is<uint32_t>()) {
+    timeoutMs_ = cfg["timeout_ms"];
+  }
+}
+
+}  // namespace InsomniaTV

--- a/src/sensors/PingSensor.h
+++ b/src/sensors/PingSensor.h
@@ -1,0 +1,34 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#ifndef SRC_SENSORS_PINGSENSOR_H_
+#define SRC_SENSORS_PINGSENSOR_H_
+
+#include <memory>
+#include <string>
+
+#include "Sensor.h"
+
+namespace InsomniaTV {
+
+class PingSensor : public Sensor {
+public:
+  PingSensor(const std::string& id, const std::string& targetIp);
+  static std::shared_ptr<Sensor> create(const JsonDocument& cfg);
+
+  std::string getId() const override { return id_; }
+  std::string getType() const override { return "ping"; }
+  bool read() override;
+  JsonDocument getConfig() override;
+  void setConfig(const JsonDocument& cfg) override;
+  bool isAvailable() const override { return lastResult_; }
+
+private:
+  std::string id_;
+  std::string targetIp_;
+  bool lastResult_;
+  uint32_t timeoutMs_;
+};
+
+}  // namespace InsomniaTV
+
+#endif  // SRC_SENSORS_PINGSENSOR_H_

--- a/src/sensors/Sensor.h
+++ b/src/sensors/Sensor.h
@@ -1,0 +1,29 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#ifndef SRC_SENSORS_SENSOR_H_
+#define SRC_SENSORS_SENSOR_H_
+
+#include <ArduinoJson.h>
+
+#include <string>
+
+namespace InsomniaTV {
+
+/**
+ * @brief Abstract base class for all sensors (hardware and software).
+ */
+class Sensor {
+public:
+  virtual std::string getId() const = 0;
+  virtual std::string getType()
+      const = 0;            // "gpio_input", "upnp", "ping", etc.
+  virtual bool read() = 0;  // Returns current state/value
+  virtual JsonDocument getConfig() = 0;
+  virtual void setConfig(const JsonDocument& cfg) = 0;
+  virtual bool isAvailable() const { return true; }  // Online/connected status
+  virtual ~Sensor() = default;
+};
+
+}  // namespace InsomniaTV
+
+#endif  // SRC_SENSORS_SENSOR_H_

--- a/src/sensors/Sensor.h
+++ b/src/sensors/Sensor.h
@@ -13,16 +13,30 @@ namespace InsomniaTV {
  * @brief Abstract base class for all sensors (hardware and software).
  */
 class Sensor {
-public:
+ public:
+  enum class State {
+    UNINITIALIZED,
+    READY,
+    ERROR,
+    RETRYING
+  };
+
   virtual std::string getId() const = 0;
-  virtual std::string getType()
-      const = 0;            // "gpio_input", "upnp", "ping", etc.
-  virtual bool read() = 0;  // Returns current state/value
+  virtual std::string getType() const = 0;
+  virtual bool read() = 0;
   virtual JsonDocument getConfig() = 0;
   virtual void setConfig(const JsonDocument& cfg) = 0;
-  virtual bool isAvailable() const { return true; }  // Online/connected status
+
+  virtual State getState() const { return state_; }
+  virtual void setState(State state) { state_ = state; }
+
+  virtual bool isAvailable() const { return state_ == State::READY; }
   virtual ~Sensor() = default;
+
+ protected:
+  State state_ = State::UNINITIALIZED;
 };
+
 
 }  // namespace InsomniaTV
 

--- a/src/sensors/Sensor.h
+++ b/src/sensors/Sensor.h
@@ -13,13 +13,8 @@ namespace InsomniaTV {
  * @brief Abstract base class for all sensors (hardware and software).
  */
 class Sensor {
- public:
-  enum class State {
-    UNINITIALIZED,
-    READY,
-    ERROR,
-    RETRYING
-  };
+public:
+  enum class State { UNINITIALIZED, READY, ERROR, RETRYING };
 
   virtual std::string getId() const = 0;
   virtual std::string getType() const = 0;
@@ -33,10 +28,9 @@ class Sensor {
   virtual bool isAvailable() const { return state_ == State::READY; }
   virtual ~Sensor() = default;
 
- protected:
+protected:
   State state_ = State::UNINITIALIZED;
 };
-
 
 }  // namespace InsomniaTV
 

--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -57,6 +57,11 @@ void SensorManager::subscribe(SensorCallback callback) {
   subscribers_.push_back(callback);
 }
 
+void SensorManager::subscribeValueChange(ValueChangeCallback callback) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  valueChangeSubscribers_.push_back(callback);
+}
+
 void SensorManager::clear() {
   std::lock_guard<std::mutex> lock(mutex_);
   sensors_.clear();
@@ -116,12 +121,25 @@ void SensorManager::init(const std::string& configJson, SamsungTvDiscovery& disc
 }
 
 void SensorManager::tick() {
-  std::lock_guard<std::mutex> lock(mutex_);
-  for (auto const& [id, sensor] : sensors_) {
-    if (sensor->read()) {
-      sensor->setState(Sensor::State::READY);
-    } else {
-      sensor->setState(Sensor::State::ERROR);
+  std::vector<std::pair<std::string, bool>> changes;
+  std::vector<ValueChangeCallback> cbs;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto const& [id, sensor] : sensors_) {
+      bool value = sensor->read();
+      sensor->setState(value ? Sensor::State::READY : Sensor::State::ERROR);
+      auto it = lastValues_.find(id);
+      if (it == lastValues_.end() || it->second != value) {
+        lastValues_[id] = value;
+        changes.emplace_back(id, value);
+      }
+    }
+    cbs = valueChangeSubscribers_;
+  }
+  // Notify outside the lock to avoid deadlock with subscribers that call back in
+  for (auto const& [id, value] : changes) {
+    for (auto& cb : cbs) {
+      cb(id, value);
     }
   }
 }

--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -28,7 +28,8 @@ void SensorManager::registerFactory(const std::string& type,
 }
 
 void SensorManager::registerSensor(std::shared_ptr<Sensor> sensor) {
-  if (!sensor) return;
+  if (!sensor)
+    return;
   std::lock_guard<std::mutex> lock(mutex_);
   sensors_[sensor->getId()] = sensor;
 
@@ -99,11 +100,13 @@ void SensorManager::init(const std::string& configJson,
     });
   }
 
-  if (configJson.empty()) return;
+  if (configJson.empty())
+    return;
 
   JsonDocument doc;
   DeserializationError error = deserializeJson(doc, configJson);
-  if (error) return;
+  if (error)
+    return;
 
   if (doc.is<JsonArray>()) {
     // Clear before re-loading to avoid orphaned sensors. Sensors registered

--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -1,7 +1,12 @@
 // Copyright 2026 insomniaTV Contributors. All rights reserved.
 
 #include "SensorManager.h"
+
 #include <ArduinoJson.h>
+
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "GpioAnalogSensor.h"
 #include "GpioInputSensor.h"
@@ -16,7 +21,8 @@ SensorManager& SensorManager::instance() {
   return instance;
 }
 
-void SensorManager::registerFactory(const std::string& type, SensorFactory factory) {
+void SensorManager::registerFactory(const std::string& type,
+                                    SensorFactory factory) {
   std::lock_guard<std::mutex> lock(mutex_);
   factories_[type] = factory;
 }
@@ -72,7 +78,8 @@ void SensorManager::removeSensor(const std::string& id) {
   sensors_.erase(id);
 }
 
-void SensorManager::init(const std::string& configJson, SamsungTvDiscovery& discovery) {
+void SensorManager::init(const std::string& configJson,
+                         SamsungTvDiscovery& discovery) {
   // Register built-in factories if map is empty
   if (factories_.empty()) {
     registerFactory("gpio_input", [](const JsonDocument& cfg) {
@@ -81,10 +88,12 @@ void SensorManager::init(const std::string& configJson, SamsungTvDiscovery& disc
     registerFactory("gpio_analog", [](const JsonDocument& cfg) {
       return GpioAnalogSensor::create(cfg);
     });
-    registerFactory("ping",
-                    [](const JsonDocument& cfg) { return PingSensor::create(cfg); });
-    registerFactory("http",
-                    [](const JsonDocument& cfg) { return HttpSensor::create(cfg); });
+    registerFactory("ping", [](const JsonDocument& cfg) {
+      return PingSensor::create(cfg);
+    });
+    registerFactory("http", [](const JsonDocument& cfg) {
+      return HttpSensor::create(cfg);
+    });
     registerFactory("upnp", [&discovery](const JsonDocument& cfg) {
       return UpnpSensor::create(cfg, discovery);
     });
@@ -97,9 +106,8 @@ void SensorManager::init(const std::string& configJson, SamsungTvDiscovery& disc
   if (error) return;
 
   if (doc.is<JsonArray>()) {
-    // We clear current sensors before re-loading from config to avoid orphaned sensors
-    // Note: If some sensors are "active" (e.g. registered manually and not in config),
-    // they will be lost. This is intended for config sync.
+    // Clear before re-loading to avoid orphaned sensors. Sensors registered
+    // manually and absent from config will be lost (intended for config sync).
     clear();
 
     for (JsonObject sensorCfg : doc.as<JsonArray>()) {
@@ -136,7 +144,7 @@ void SensorManager::tick() {
     }
     cbs = valueChangeSubscribers_;
   }
-  // Notify outside the lock to avoid deadlock with subscribers that call back in
+  // Notify outside the lock to avoid deadlock with re-entrant subscribers.
   for (auto const& [id, value] : changes) {
     for (auto& cb : cbs) {
       cb(id, value);

--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -1,7 +1,6 @@
 // Copyright 2026 insomniaTV Contributors. All rights reserved.
 
 #include "SensorManager.h"
-
 #include <ArduinoJson.h>
 
 #include "GpioAnalogSensor.h"
@@ -17,15 +16,13 @@ SensorManager& SensorManager::instance() {
   return instance;
 }
 
-void SensorManager::registerFactory(const std::string& type,
-                                    SensorFactory factory) {
+void SensorManager::registerFactory(const std::string& type, SensorFactory factory) {
   std::lock_guard<std::mutex> lock(mutex_);
   factories_[type] = factory;
 }
 
 void SensorManager::registerSensor(std::shared_ptr<Sensor> sensor) {
-  if (!sensor)
-    return;
+  if (!sensor) return;
   std::lock_guard<std::mutex> lock(mutex_);
   sensors_[sensor->getId()] = sensor;
 
@@ -60,21 +57,33 @@ void SensorManager::subscribe(SensorCallback callback) {
   subscribers_.push_back(callback);
 }
 
+void SensorManager::clear() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  sensors_.clear();
+}
+
+void SensorManager::removeSensor(const std::string& id) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  sensors_.erase(id);
+}
+
 void SensorManager::init(const std::string& configJson, SamsungTvDiscovery& discovery) {
-  // Register built-in factories
-  registerFactory("gpio_input", [](const JsonDocument& cfg) {
-    return GpioInputSensor::create(cfg);
-  });
-  registerFactory("gpio_analog", [](const JsonDocument& cfg) {
-    return GpioAnalogSensor::create(cfg);
-  });
-  registerFactory("ping",
-                  [](const JsonDocument& cfg) { return PingSensor::create(cfg); });
-  registerFactory("http",
-                  [](const JsonDocument& cfg) { return HttpSensor::create(cfg); });
-  registerFactory("upnp", [&discovery](const JsonDocument& cfg) {
-    return UpnpSensor::create(cfg, discovery);
-  });
+  // Register built-in factories if map is empty
+  if (factories_.empty()) {
+    registerFactory("gpio_input", [](const JsonDocument& cfg) {
+      return GpioInputSensor::create(cfg);
+    });
+    registerFactory("gpio_analog", [](const JsonDocument& cfg) {
+      return GpioAnalogSensor::create(cfg);
+    });
+    registerFactory("ping",
+                    [](const JsonDocument& cfg) { return PingSensor::create(cfg); });
+    registerFactory("http",
+                    [](const JsonDocument& cfg) { return HttpSensor::create(cfg); });
+    registerFactory("upnp", [&discovery](const JsonDocument& cfg) {
+      return UpnpSensor::create(cfg, discovery);
+    });
+  }
 
   if (configJson.empty()) return;
 
@@ -83,6 +92,11 @@ void SensorManager::init(const std::string& configJson, SamsungTvDiscovery& disc
   if (error) return;
 
   if (doc.is<JsonArray>()) {
+    // We clear current sensors before re-loading from config to avoid orphaned sensors
+    // Note: If some sensors are "active" (e.g. registered manually and not in config),
+    // they will be lost. This is intended for config sync.
+    clear();
+
     for (JsonObject sensorCfg : doc.as<JsonArray>()) {
       std::string type = sensorCfg["type"] | "";
       std::string id = sensorCfg["id"] | "";
@@ -111,6 +125,5 @@ void SensorManager::tick() {
     }
   }
 }
-
 
 }  // namespace InsomniaTV

--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -1,0 +1,106 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#include "SensorManager.h"
+
+#include <ArduinoJson.h>
+
+#include "GpioAnalogSensor.h"
+#include "GpioInputSensor.h"
+#include "HttpSensor.h"
+#include "PingSensor.h"
+#include "UpnpSensor.h"
+
+namespace InsomniaTV {
+
+SensorManager& SensorManager::instance() {
+  static SensorManager instance;
+  return instance;
+}
+
+void SensorManager::registerFactory(const std::string& type,
+                                    SensorFactory factory) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  factories_[type] = factory;
+}
+
+void SensorManager::registerSensor(std::shared_ptr<Sensor> sensor) {
+  if (!sensor)
+    return;
+  std::lock_guard<std::mutex> lock(mutex_);
+  sensors_[sensor->getId()] = sensor;
+
+  for (auto& cb : subscribers_) {
+    cb(sensor);
+  }
+}
+
+std::shared_ptr<Sensor> SensorManager::getSensor(const std::string& id) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = sensors_.find(id);
+  if (it != sensors_.end()) {
+    return it->second;
+  }
+  return nullptr;
+}
+
+std::vector<std::shared_ptr<Sensor>> SensorManager::listSensors(
+    const std::string& type) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::vector<std::shared_ptr<Sensor>> result;
+  for (auto const& [id, sensor] : sensors_) {
+    if (type == "" || sensor->getType() == type) {
+      result.push_back(sensor);
+    }
+  }
+  return result;
+}
+
+void SensorManager::subscribe(SensorCallback callback) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  subscribers_.push_back(callback);
+}
+
+void SensorManager::init(const std::string& configJson,
+                         SamsungTvDiscovery& discovery) {
+  // Register built-in factories
+  registerFactory("gpio_input", [](const JsonDocument& cfg) {
+    return GpioInputSensor::create(cfg);
+  });
+  registerFactory("gpio_analog", [](const JsonDocument& cfg) {
+    return GpioAnalogSensor::create(cfg);
+  });
+  registerFactory(
+      "ping", [](const JsonDocument& cfg) { return PingSensor::create(cfg); });
+  registerFactory(
+      "http", [](const JsonDocument& cfg) { return HttpSensor::create(cfg); });
+  registerFactory("upnp", [&discovery](const JsonDocument& cfg) {
+    return UpnpSensor::create(cfg, discovery);
+  });
+
+  if (configJson.empty())
+    return;
+
+  JsonDocument doc;
+  DeserializationError error = deserializeJson(doc, configJson);
+  if (error)
+    return;
+
+  if (doc.is<JsonArray>()) {
+    for (JsonObject sensorCfg : doc.as<JsonArray>()) {
+      std::string type = sensorCfg["type"] | "";
+      std::string id = sensorCfg["id"] | "";
+
+      if (type != "" && id != "") {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (factories_.count(type)) {
+          auto sensor = factories_[type](sensorCfg);
+          if (sensor) {
+            sensors_[id] = sensor;
+          }
+        }
+      }
+    }
+  }
+}
+
+}  // namespace InsomniaTV

--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -60,8 +60,7 @@ void SensorManager::subscribe(SensorCallback callback) {
   subscribers_.push_back(callback);
 }
 
-void SensorManager::init(const std::string& configJson,
-                         SamsungTvDiscovery& discovery) {
+void SensorManager::init(const std::string& configJson, SamsungTvDiscovery& discovery) {
   // Register built-in factories
   registerFactory("gpio_input", [](const JsonDocument& cfg) {
     return GpioInputSensor::create(cfg);
@@ -69,21 +68,19 @@ void SensorManager::init(const std::string& configJson,
   registerFactory("gpio_analog", [](const JsonDocument& cfg) {
     return GpioAnalogSensor::create(cfg);
   });
-  registerFactory(
-      "ping", [](const JsonDocument& cfg) { return PingSensor::create(cfg); });
-  registerFactory(
-      "http", [](const JsonDocument& cfg) { return HttpSensor::create(cfg); });
+  registerFactory("ping",
+                  [](const JsonDocument& cfg) { return PingSensor::create(cfg); });
+  registerFactory("http",
+                  [](const JsonDocument& cfg) { return HttpSensor::create(cfg); });
   registerFactory("upnp", [&discovery](const JsonDocument& cfg) {
     return UpnpSensor::create(cfg, discovery);
   });
 
-  if (configJson.empty())
-    return;
+  if (configJson.empty()) return;
 
   JsonDocument doc;
   DeserializationError error = deserializeJson(doc, configJson);
-  if (error)
-    return;
+  if (error) return;
 
   if (doc.is<JsonArray>()) {
     for (JsonObject sensorCfg : doc.as<JsonArray>()) {
@@ -95,6 +92,7 @@ void SensorManager::init(const std::string& configJson,
         if (factories_.count(type)) {
           auto sensor = factories_[type](sensorCfg);
           if (sensor) {
+            sensor->setState(Sensor::State::READY);
             sensors_[id] = sensor;
           }
         }
@@ -102,5 +100,17 @@ void SensorManager::init(const std::string& configJson,
     }
   }
 }
+
+void SensorManager::tick() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (auto const& [id, sensor] : sensors_) {
+    if (sensor->read()) {
+      sensor->setState(Sensor::State::READY);
+    } else {
+      sensor->setState(Sensor::State::ERROR);
+    }
+  }
+}
+
 
 }  // namespace InsomniaTV

--- a/src/sensors/SensorManager.h
+++ b/src/sensors/SensorManager.h
@@ -44,7 +44,8 @@ public:
   // Subscribe to sensor registration events
   void subscribe(SensorCallback callback);
 
-  // Subscribe to sensor value changes (fires only when value differs from last read)
+  // Subscribe to sensor value changes (fires only when value differs from
+  // last read)
   void subscribeValueChange(ValueChangeCallback callback);
 
   // Thread-safe access to all sensors
@@ -54,7 +55,6 @@ public:
   void removeSensor(const std::string& id);
 
  private:
-
   SensorManager() = default;
   ~SensorManager() = default;
   SensorManager(const SensorManager&) = delete;

--- a/src/sensors/SensorManager.h
+++ b/src/sensors/SensorManager.h
@@ -54,7 +54,7 @@ public:
   void clear();
   void removeSensor(const std::string& id);
 
- private:
+private:
   SensorManager() = default;
   ~SensorManager() = default;
   SensorManager(const SensorManager&) = delete;

--- a/src/sensors/SensorManager.h
+++ b/src/sensors/SensorManager.h
@@ -44,8 +44,10 @@ public:
 
   // Thread-safe access to all sensors
   void init(const std::string& configJson, SamsungTvDiscovery& discovery);
+  void tick();
 
-private:
+  private:
+
   SensorManager() = default;
   ~SensorManager() = default;
   SensorManager(const SensorManager&) = delete;

--- a/src/sensors/SensorManager.h
+++ b/src/sensors/SensorManager.h
@@ -45,8 +45,10 @@ public:
   // Thread-safe access to all sensors
   void init(const std::string& configJson, SamsungTvDiscovery& discovery);
   void tick();
+  void clear();
+  void removeSensor(const std::string& id);
 
-  private:
+ private:
 
   SensorManager() = default;
   ~SensorManager() = default;

--- a/src/sensors/SensorManager.h
+++ b/src/sensors/SensorManager.h
@@ -1,0 +1,62 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#ifndef SRC_SENSORS_SENSORMANAGER_H_
+#define SRC_SENSORS_SENSORMANAGER_H_
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "../discovery/SamsungTvDiscovery.h"
+#include "Sensor.h"
+
+namespace InsomniaTV {
+
+using SensorCallback = std::function<void(std::shared_ptr<Sensor>)>;
+using SensorFactory =
+    std::function<std::shared_ptr<Sensor>(const JsonDocument&)>;
+
+/**
+ * @brief Singleton manager for all sensors in the system.
+ */
+class SensorManager {
+public:
+  static SensorManager& instance();
+
+  // Register a sensor factory for a specific type
+  void registerFactory(const std::string& type, SensorFactory factory);
+
+  // Register a sensor instance
+  void registerSensor(std::shared_ptr<Sensor> sensor);
+
+  // Get a sensor by its unique ID
+  std::shared_ptr<Sensor> getSensor(const std::string& id);
+
+  // List all sensors, optionally filtered by type
+  std::vector<std::shared_ptr<Sensor>> listSensors(
+      const std::string& type = "");
+
+  // Subscribe to all sensor changes (or additions)
+  void subscribe(SensorCallback callback);
+
+  // Thread-safe access to all sensors
+  void init(const std::string& configJson, SamsungTvDiscovery& discovery);
+
+private:
+  SensorManager() = default;
+  ~SensorManager() = default;
+  SensorManager(const SensorManager&) = delete;
+  SensorManager& operator=(const SensorManager&) = delete;
+
+  std::map<std::string, std::shared_ptr<Sensor>> sensors_;
+  std::map<std::string, SensorFactory> factories_;
+  std::vector<SensorCallback> subscribers_;
+  mutable std::mutex mutex_;
+};
+
+}  // namespace InsomniaTV
+
+#endif  // SRC_SENSORS_SENSORMANAGER_H_

--- a/src/sensors/SensorManager.h
+++ b/src/sensors/SensorManager.h
@@ -18,6 +18,8 @@ namespace InsomniaTV {
 using SensorCallback = std::function<void(std::shared_ptr<Sensor>)>;
 using SensorFactory =
     std::function<std::shared_ptr<Sensor>(const JsonDocument&)>;
+using ValueChangeCallback =
+    std::function<void(const std::string& id, bool value)>;
 
 /**
  * @brief Singleton manager for all sensors in the system.
@@ -39,8 +41,11 @@ public:
   std::vector<std::shared_ptr<Sensor>> listSensors(
       const std::string& type = "");
 
-  // Subscribe to all sensor changes (or additions)
+  // Subscribe to sensor registration events
   void subscribe(SensorCallback callback);
+
+  // Subscribe to sensor value changes (fires only when value differs from last read)
+  void subscribeValueChange(ValueChangeCallback callback);
 
   // Thread-safe access to all sensors
   void init(const std::string& configJson, SamsungTvDiscovery& discovery);
@@ -58,6 +63,8 @@ public:
   std::map<std::string, std::shared_ptr<Sensor>> sensors_;
   std::map<std::string, SensorFactory> factories_;
   std::vector<SensorCallback> subscribers_;
+  std::vector<ValueChangeCallback> valueChangeSubscribers_;
+  std::map<std::string, bool> lastValues_;
   mutable std::mutex mutex_;
 };
 

--- a/src/sensors/UpnpSensor.cpp
+++ b/src/sensors/UpnpSensor.cpp
@@ -1,0 +1,53 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#include "UpnpSensor.h"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+
+namespace InsomniaTV {
+
+UpnpSensor::UpnpSensor(const std::string& id, SamsungTvDiscovery& discovery,
+                       const std::string& targetName)
+    : id_(id),
+      discovery_(discovery),
+      targetName_(targetName),
+      lastResult_(false) {}
+
+std::shared_ptr<Sensor> UpnpSensor::create(const JsonDocument& cfg,
+                                           SamsungTvDiscovery& discovery) {
+  std::string id = cfg["id"] | "";
+  std::string targetName = cfg["target_name"] | "";
+  if (id == "")
+    return nullptr;
+  auto sensor = std::make_shared<UpnpSensor>(id, discovery, targetName);
+  sensor->setConfig(cfg);
+  return sensor;
+}
+
+bool UpnpSensor::read() {
+  const auto& tvs = discovery_.getDiscoveredTvs();
+  auto it =
+      std::find_if(tvs.begin(), tvs.end(), [this](const SamsungTvInfo& info) {
+        return info.name == targetName_ || info.ip == targetName_;
+      });
+  lastResult_ = (it != tvs.end());
+  return lastResult_;
+}
+
+JsonDocument UpnpSensor::getConfig() {
+  JsonDocument doc;
+  doc["id"] = id_;
+  doc["type"] = "upnp";
+  doc["target_name"] = targetName_;
+  return doc;
+}
+
+void UpnpSensor::setConfig(const JsonDocument& cfg) {
+  if (cfg["target_name"].is<std::string>()) {
+    targetName_ = cfg["target_name"].as<std::string>();
+  }
+}
+
+}  // namespace InsomniaTV

--- a/src/sensors/UpnpSensor.h
+++ b/src/sensors/UpnpSensor.h
@@ -1,0 +1,37 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#ifndef SRC_SENSORS_UPNPSENSOR_H_
+#define SRC_SENSORS_UPNPSENSOR_H_
+
+#include <memory>
+#include <string>
+
+#include "../discovery/SamsungTvDiscovery.h"
+#include "Sensor.h"
+
+namespace InsomniaTV {
+
+class UpnpSensor : public Sensor {
+public:
+  UpnpSensor(const std::string& id, SamsungTvDiscovery& discovery,
+             const std::string& targetName);
+  static std::shared_ptr<Sensor> create(const JsonDocument& cfg,
+                                        SamsungTvDiscovery& discovery);
+
+  std::string getId() const override { return id_; }
+  std::string getType() const override { return "upnp"; }
+  bool read() override;
+  JsonDocument getConfig() override;
+  void setConfig(const JsonDocument& cfg) override;
+  bool isAvailable() const override { return lastResult_; }
+
+private:
+  std::string id_;
+  SamsungTvDiscovery& discovery_;
+  std::string targetName_;
+  bool lastResult_;
+};
+
+}  // namespace InsomniaTV
+
+#endif  // SRC_SENSORS_UPNPSENSOR_H_

--- a/src/state/SleepStateMachine.cpp
+++ b/src/state/SleepStateMachine.cpp
@@ -41,18 +41,21 @@ void SleepStateMachine::tick() {
       }
       current_ = next;
       // Fall through to execute the power-off action immediately.
-      if (powerOffCallback_) powerOffCallback_();
+      if (powerOffCallback_)
+        powerOffCallback_();
       resetToMonitoring();
       break;
     }
 
     case State::POWERING_OFF:
-      if (powerOffCallback_) powerOffCallback_();
+      if (powerOffCallback_)
+        powerOffCallback_();
       resetToMonitoring();
       break;
 
     case State::FALLBACK_OFF:
-      if (powerOffCallback_) powerOffCallback_();
+      if (powerOffCallback_)
+        powerOffCallback_();
       resetToMonitoring();
       break;
   }

--- a/src/state/SleepStateMachine.cpp
+++ b/src/state/SleepStateMachine.cpp
@@ -2,20 +2,87 @@
 
 #include "SleepStateMachine.h"
 
+#include "../tv/TvStateMachine.h"
+
 namespace InsomniaTV {
 
-SleepStateMachine::SleepStateMachine() : _current_state(State::MONITORING) {}
+SleepStateMachine::SleepStateMachine(IClock& clock,
+                                     uint32_t inactivityTimeoutMs)
+    : clock_(clock),
+      inactivityTimeoutMs_(inactivityTimeoutMs),
+      lastActivityMs_(clock.nowMs()),
+      current_(State::MONITORING),
+      tvStateMachine_(nullptr) {}
 
 void SleepStateMachine::tick() {
-  // State machine logic
+  switch (current_) {
+    case State::MONITORING:
+      if (clock_.nowMs() - lastActivityMs_ >= inactivityTimeoutMs_) {
+        current_ = State::RAMPING;
+      }
+      break;
+
+    case State::RAMPING:
+      // Transition driven by onRampComplete(); nothing to do here.
+      break;
+
+    case State::VERIFYING: {
+      State next = State::POWERING_OFF;
+      if (tvStateMachine_) {
+        auto ps = tvStateMachine_->getPowerState();
+        if (ps == TvStateMachine::PowerState::OFF) {
+          // TV already off — nothing to do.
+          resetToMonitoring();
+          return;
+        } else if (ps == TvStateMachine::PowerState::UNKNOWN) {
+          next = State::FALLBACK_OFF;
+        }
+        // ON or TRANSITIONING → proceed to POWERING_OFF
+      }
+      current_ = next;
+      // Fall through to execute the power-off action immediately.
+      if (powerOffCallback_) powerOffCallback_();
+      resetToMonitoring();
+      break;
+    }
+
+    case State::POWERING_OFF:
+      if (powerOffCallback_) powerOffCallback_();
+      resetToMonitoring();
+      break;
+
+    case State::FALLBACK_OFF:
+      if (powerOffCallback_) powerOffCallback_();
+      resetToMonitoring();
+      break;
+  }
 }
 
 void SleepStateMachine::onIrActivity() {
-  _current_state = State::MONITORING;
+  resetToMonitoring();
+}
+
+void SleepStateMachine::onRampComplete() {
+  if (current_ == State::RAMPING) {
+    current_ = State::VERIFYING;
+  }
 }
 
 State SleepStateMachine::getCurrentState() const {
-  return _current_state;
+  return current_;
+}
+
+void SleepStateMachine::setTvStateMachine(TvStateMachine* tv) {
+  tvStateMachine_ = tv;
+}
+
+void SleepStateMachine::setPowerOffCallback(std::function<void()> callback) {
+  powerOffCallback_ = callback;
+}
+
+void SleepStateMachine::resetToMonitoring() {
+  current_ = State::MONITORING;
+  lastActivityMs_ = clock_.nowMs();
 }
 
 }  // namespace InsomniaTV

--- a/src/state/SleepStateMachine.h
+++ b/src/state/SleepStateMachine.h
@@ -4,25 +4,57 @@
 #define SRC_STATE_SLEEPSTATEMACHINE_H_
 
 #include <cstdint>
-#include <string>
+#include <functional>
+
+#include "../hal/IClock.h"
 
 namespace InsomniaTV {
+
+class TvStateMachine;  // forward declaration
 
 enum class State { MONITORING, RAMPING, VERIFYING, POWERING_OFF, FALLBACK_OFF };
 
 /**
- * @brief Manages the TV sleep state machine.
+ * @brief Drives the sleep sequence: monitor IR → ramp volume → verify TV
+ *        state → send power-off.
+ *
+ * State transitions:
+ *   MONITORING  ──(inactivity timeout)──► RAMPING
+ *   RAMPING     ──(onRampComplete)──────► VERIFYING
+ *   VERIFYING   ──(TV OFF)─────────────► MONITORING  (already off, done)
+ *               ──(TV ON or no SM)──────► POWERING_OFF
+ *               ──(TV UNKNOWN)──────────► FALLBACK_OFF
+ *   POWERING_OFF / FALLBACK_OFF  ───────► MONITORING  (fires power callback)
+ *
+ *   Any state  ──(onIrActivity)─────────► MONITORING
  */
 class SleepStateMachine {
-public:
-  SleepStateMachine();
+ public:
+  explicit SleepStateMachine(IClock& clock,
+                             uint32_t inactivityTimeoutMs = 30000);
 
   void tick();
   void onIrActivity();
+  void onRampComplete();
+
   State getCurrentState() const;
 
-private:
-  State _current_state;
+  // Optional: supply TvStateMachine for VERIFYING state decisions.
+  void setTvStateMachine(TvStateMachine* tv);
+
+  // Callback invoked when a power-off command should be sent.
+  void setPowerOffCallback(std::function<void()> callback);
+
+ private:
+  void resetToMonitoring();
+
+  IClock& clock_;
+  uint32_t inactivityTimeoutMs_;
+  uint32_t lastActivityMs_;
+
+  State current_;
+  TvStateMachine* tvStateMachine_;
+  std::function<void()> powerOffCallback_;
 };
 
 }  // namespace InsomniaTV

--- a/src/state/SleepStateMachine.h
+++ b/src/state/SleepStateMachine.h
@@ -29,7 +29,7 @@ enum class State { MONITORING, RAMPING, VERIFYING, POWERING_OFF, FALLBACK_OFF };
  *   Any state  ──(onIrActivity)─────────► MONITORING
  */
 class SleepStateMachine {
- public:
+public:
   explicit SleepStateMachine(IClock& clock,
                              uint32_t inactivityTimeoutMs = 30000);
 
@@ -45,7 +45,7 @@ class SleepStateMachine {
   // Callback invoked when a power-off command should be sent.
   void setPowerOffCallback(std::function<void()> callback);
 
- private:
+private:
   void resetToMonitoring();
 
   IClock& clock_;

--- a/src/system/fs/FileSystemManager.cpp
+++ b/src/system/fs/FileSystemManager.cpp
@@ -1,12 +1,19 @@
 // Copyright 2026 insomniaTV Contributors. All rights reserved.
 
 #include "FileSystemManager.h"
+#include <string>
 
+#if defined(ARDUINO)
 #include <Arduino.h>
+#endif
 
 namespace InsomniaTV {
 
-FileSystemManager::FileSystemManager() : _fs(&LittleFS) {}
+FileSystemManager::FileSystemManager() {
+#if defined(ARDUINO)
+  _fs = &LittleFS;
+#endif
+}
 
 bool FileSystemManager::mount() {
 #if defined(ARDUINO)
@@ -19,8 +26,7 @@ bool FileSystemManager::mount() {
 std::string FileSystemManager::readJson(const std::string& path) {
 #if defined(ARDUINO)
   File file = _fs->open(path.c_str(), "r");
-  if (!file)
-    return "";
+  if (!file) return "";
   String content = file.readString();
   file.close();
   return content.c_str();
@@ -33,8 +39,7 @@ bool FileSystemManager::writeJson(const std::string& path,
                                   const std::string& json) {
 #if defined(ARDUINO)
   File file = _fs->open(path.c_str(), "w");
-  if (!file)
-    return false;
+  if (!file) return false;
   file.print(json.c_str());
   file.close();
   return true;
@@ -47,8 +52,7 @@ bool FileSystemManager::uploadFile(const std::string& path, const uint8_t* data,
                                    size_t len) {
 #if defined(ARDUINO)
   File file = _fs->open(path.c_str(), "w");
-  if (!file)
-    return false;
+  if (!file) return false;
   file.write(data, len);
   file.close();
   return true;
@@ -61,8 +65,7 @@ int32_t FileSystemManager::downloadFile(const std::string& path,
                                         uint8_t* outBuf, size_t bufSize) {
 #if defined(ARDUINO)
   File file = _fs->open(path.c_str(), "r");
-  if (!file)
-    return -1;
+  if (!file) return -1;
   size_t len = file.read(outBuf, bufSize);
   file.close();
   return static_cast<int32_t>(len);

--- a/src/system/fs/FileSystemManager.cpp
+++ b/src/system/fs/FileSystemManager.cpp
@@ -26,9 +26,11 @@ bool FileSystemManager::mount() {
 
 std::string FileSystemManager::readJson(const std::string& path) {
 #if defined(ARDUINO)
-  if (!_fs) return "";
+  if (!_fs)
+    return "";
   File file = _fs->open(path.c_str(), "r");
-  if (!file) return "";
+  if (!file)
+    return "";
   String content = file.readString();
   file.close();
   return content.c_str();
@@ -40,9 +42,11 @@ std::string FileSystemManager::readJson(const std::string& path) {
 bool FileSystemManager::writeJson(const std::string& path,
                                   const std::string& json) {
 #if defined(ARDUINO)
-  if (!_fs) return false;
+  if (!_fs)
+    return false;
   File file = _fs->open(path.c_str(), "w");
-  if (!file) return false;
+  if (!file)
+    return false;
   file.print(json.c_str());
   file.close();
   return true;
@@ -54,9 +58,11 @@ bool FileSystemManager::writeJson(const std::string& path,
 bool FileSystemManager::uploadFile(const std::string& path, const uint8_t* data,
                                    size_t len) {
 #if defined(ARDUINO)
-  if (!_fs) return false;
+  if (!_fs)
+    return false;
   File file = _fs->open(path.c_str(), "w");
-  if (!file) return false;
+  if (!file)
+    return false;
   file.write(data, len);
   file.close();
   return true;
@@ -68,9 +74,11 @@ bool FileSystemManager::uploadFile(const std::string& path, const uint8_t* data,
 int32_t FileSystemManager::downloadFile(const std::string& path,
                                         uint8_t* outBuf, size_t bufSize) {
 #if defined(ARDUINO)
-  if (!_fs) return -1;
+  if (!_fs)
+    return -1;
   File file = _fs->open(path.c_str(), "r");
-  if (!file) return -1;
+  if (!file)
+    return -1;
   size_t len = file.read(outBuf, bufSize);
   file.close();
   return static_cast<int32_t>(len);
@@ -81,7 +89,8 @@ int32_t FileSystemManager::downloadFile(const std::string& path,
 
 bool FileSystemManager::exists(const std::string& path) const {
 #if defined(ARDUINO)
-  if (!_fs) return false;
+  if (!_fs)
+    return false;
   return _fs->exists(path.c_str());
 #else
   return false;
@@ -90,7 +99,8 @@ bool FileSystemManager::exists(const std::string& path) const {
 
 bool FileSystemManager::remove(const std::string& path) {
 #if defined(ARDUINO)
-  if (!_fs) return false;
+  if (!_fs)
+    return false;
   return _fs->remove(path.c_str());
 #else
   return false;

--- a/src/system/fs/FileSystemManager.cpp
+++ b/src/system/fs/FileSystemManager.cpp
@@ -1,0 +1,90 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#include "FileSystemManager.h"
+
+#include <Arduino.h>
+
+namespace InsomniaTV {
+
+FileSystemManager::FileSystemManager() : _fs(&LittleFS) {}
+
+bool FileSystemManager::mount() {
+#if defined(ARDUINO)
+  return LittleFS.begin(true);
+#else
+  return false;
+#endif
+}
+
+std::string FileSystemManager::readJson(const std::string& path) {
+#if defined(ARDUINO)
+  File file = _fs->open(path.c_str(), "r");
+  if (!file)
+    return "";
+  String content = file.readString();
+  file.close();
+  return content.c_str();
+#else
+  return "";
+#endif
+}
+
+bool FileSystemManager::writeJson(const std::string& path,
+                                  const std::string& json) {
+#if defined(ARDUINO)
+  File file = _fs->open(path.c_str(), "w");
+  if (!file)
+    return false;
+  file.print(json.c_str());
+  file.close();
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool FileSystemManager::uploadFile(const std::string& path, const uint8_t* data,
+                                   size_t len) {
+#if defined(ARDUINO)
+  File file = _fs->open(path.c_str(), "w");
+  if (!file)
+    return false;
+  file.write(data, len);
+  file.close();
+  return true;
+#else
+  return false;
+#endif
+}
+
+int32_t FileSystemManager::downloadFile(const std::string& path,
+                                        uint8_t* outBuf, size_t bufSize) {
+#if defined(ARDUINO)
+  File file = _fs->open(path.c_str(), "r");
+  if (!file)
+    return -1;
+  size_t len = file.read(outBuf, bufSize);
+  file.close();
+  return static_cast<int32_t>(len);
+#else
+  return -1;
+#endif
+}
+
+bool FileSystemManager::exists(const std::string& path) const {
+#if defined(ARDUINO)
+  return _fs->exists(path.c_str());
+#else
+  return false;
+#endif
+}
+
+bool FileSystemManager::remove(const std::string& path) {
+#if defined(ARDUINO)
+  return _fs->remove(path.c_str());
+#else
+  return false;
+#endif
+}
+
+}  // namespace InsomniaTV

--- a/src/system/fs/FileSystemManager.cpp
+++ b/src/system/fs/FileSystemManager.cpp
@@ -1,6 +1,7 @@
 // Copyright 2026 insomniaTV Contributors. All rights reserved.
 
 #include "FileSystemManager.h"
+
 #include <string>
 
 #if defined(ARDUINO)
@@ -25,6 +26,7 @@ bool FileSystemManager::mount() {
 
 std::string FileSystemManager::readJson(const std::string& path) {
 #if defined(ARDUINO)
+  if (!_fs) return "";
   File file = _fs->open(path.c_str(), "r");
   if (!file) return "";
   String content = file.readString();
@@ -38,6 +40,7 @@ std::string FileSystemManager::readJson(const std::string& path) {
 bool FileSystemManager::writeJson(const std::string& path,
                                   const std::string& json) {
 #if defined(ARDUINO)
+  if (!_fs) return false;
   File file = _fs->open(path.c_str(), "w");
   if (!file) return false;
   file.print(json.c_str());
@@ -51,6 +54,7 @@ bool FileSystemManager::writeJson(const std::string& path,
 bool FileSystemManager::uploadFile(const std::string& path, const uint8_t* data,
                                    size_t len) {
 #if defined(ARDUINO)
+  if (!_fs) return false;
   File file = _fs->open(path.c_str(), "w");
   if (!file) return false;
   file.write(data, len);
@@ -64,6 +68,7 @@ bool FileSystemManager::uploadFile(const std::string& path, const uint8_t* data,
 int32_t FileSystemManager::downloadFile(const std::string& path,
                                         uint8_t* outBuf, size_t bufSize) {
 #if defined(ARDUINO)
+  if (!_fs) return -1;
   File file = _fs->open(path.c_str(), "r");
   if (!file) return -1;
   size_t len = file.read(outBuf, bufSize);
@@ -76,6 +81,7 @@ int32_t FileSystemManager::downloadFile(const std::string& path,
 
 bool FileSystemManager::exists(const std::string& path) const {
 #if defined(ARDUINO)
+  if (!_fs) return false;
   return _fs->exists(path.c_str());
 #else
   return false;
@@ -84,6 +90,7 @@ bool FileSystemManager::exists(const std::string& path) const {
 
 bool FileSystemManager::remove(const std::string& path) {
 #if defined(ARDUINO)
+  if (!_fs) return false;
   return _fs->remove(path.c_str());
 #else
   return false;

--- a/src/system/fs/FileSystemManager.h
+++ b/src/system/fs/FileSystemManager.h
@@ -3,15 +3,18 @@
 #ifndef SRC_SYSTEM_FS_FILESYSTEMMANAGER_H_
 #define SRC_SYSTEM_FS_FILESYSTEMMANAGER_H_
 
+#include <string>
+#include "../../hal/IFileSystem.h"
+
+#if defined(ARDUINO)
 #include <FS.h>
 #include <LittleFS.h>
-
-#include "../../hal/IFileSystem.h"
+#endif
 
 namespace InsomniaTV {
 
 class FileSystemManager : public IFileSystem {
-public:
+ public:
   FileSystemManager();
   bool mount() override;
   std::string readJson(const std::string& path) override;
@@ -23,8 +26,10 @@ public:
   bool exists(const std::string& path) const override;
   bool remove(const std::string& path) override;
 
-private:
+ private:
+#if defined(ARDUINO)
   fs::FS* _fs;
+#endif
 };
 
 }  // namespace InsomniaTV

--- a/src/system/fs/FileSystemManager.h
+++ b/src/system/fs/FileSystemManager.h
@@ -15,7 +15,7 @@
 namespace InsomniaTV {
 
 class FileSystemManager : public IFileSystem {
- public:
+public:
   FileSystemManager();
   bool mount() override;
   std::string readJson(const std::string& path) override;
@@ -27,7 +27,7 @@ class FileSystemManager : public IFileSystem {
   bool exists(const std::string& path) const override;
   bool remove(const std::string& path) override;
 
- private:
+private:
 #if defined(ARDUINO)
   fs::FS* _fs;
 #endif

--- a/src/system/fs/FileSystemManager.h
+++ b/src/system/fs/FileSystemManager.h
@@ -1,0 +1,32 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#ifndef SRC_SYSTEM_FS_FILESYSTEMMANAGER_H_
+#define SRC_SYSTEM_FS_FILESYSTEMMANAGER_H_
+
+#include <FS.h>
+#include <LittleFS.h>
+
+#include "../../hal/IFileSystem.h"
+
+namespace InsomniaTV {
+
+class FileSystemManager : public IFileSystem {
+public:
+  FileSystemManager();
+  bool mount() override;
+  std::string readJson(const std::string& path) override;
+  bool writeJson(const std::string& path, const std::string& json) override;
+  bool uploadFile(const std::string& path, const uint8_t* data,
+                  size_t len) override;
+  int32_t downloadFile(const std::string& path, uint8_t* outBuf,
+                       size_t bufSize) override;
+  bool exists(const std::string& path) const override;
+  bool remove(const std::string& path) override;
+
+private:
+  fs::FS* _fs;
+};
+
+}  // namespace InsomniaTV
+
+#endif  // SRC_SYSTEM_FS_FILESYSTEMMANAGER_H_

--- a/src/system/fs/FileSystemManager.h
+++ b/src/system/fs/FileSystemManager.h
@@ -4,6 +4,7 @@
 #define SRC_SYSTEM_FS_FILESYSTEMMANAGER_H_
 
 #include <string>
+
 #include "../../hal/IFileSystem.h"
 
 #if defined(ARDUINO)

--- a/src/tv/TvStateMachine.cpp
+++ b/src/tv/TvStateMachine.cpp
@@ -8,7 +8,7 @@
 namespace InsomniaTV {
 
 TvStateMachine::TvStateMachine(SensorManager& sensorManager,
-                                int hysteresisCount)
+                               int hysteresisCount)
     : sensorManager_(sensorManager),
       hysteresisCount_(hysteresisCount),
       currentState_(PowerState::UNKNOWN),
@@ -55,7 +55,8 @@ bool TvStateMachine::sendPowerCommand(bool on) {
   std::function<void(bool)> cb;
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    if (!powerCommandCallback_) return false;
+    if (!powerCommandCallback_)
+      return false;
     currentState_ = PowerState::TRANSITIONING;
     cb = powerCommandCallback_;
   }
@@ -85,10 +86,9 @@ TvStateMachine::getContributions() const {
     auto it = sensorValues_.find(sc.sensorId);
     contrib.available = (it != sensorValues_.end());
     contrib.rawValue = contrib.available ? it->second : false;
-    contrib.weightedVote =
-        (sc.enabled && contrib.available)
-            ? sc.weight * (contrib.rawValue ? +1 : -1)
-            : 0;
+    contrib.weightedVote = (sc.enabled && contrib.available)
+                               ? sc.weight * (contrib.rawValue ? +1 : -1)
+                               : 0;
     result.push_back(contrib);
   }
   return result;
@@ -104,7 +104,8 @@ void TvStateMachine::onSensorUpdate(const std::string& sensorId, bool value) {
     newState = currentState_;
   }
   if (changed) {
-    for (auto& cb : subscribers_) cb(newState);
+    for (auto& cb : subscribers_)
+      cb(newState);
   }
 }
 
@@ -112,13 +113,16 @@ float TvStateMachine::calculateConfidence() const {
   int votes = 0;
   int maxVotes = 0;
   for (const auto& sc : detectionSensors_) {
-    if (!sc.enabled) continue;
+    if (!sc.enabled)
+      continue;
     auto it = sensorValues_.find(sc.sensorId);
-    if (it == sensorValues_.end()) continue;
+    if (it == sensorValues_.end())
+      continue;
     votes += sc.weight * (it->second ? +1 : -1);
     maxVotes += sc.weight;
   }
-  if (maxVotes == 0) return 0.0f;
+  if (maxVotes == 0)
+    return 0.0f;
   return static_cast<float>(votes) / maxVotes * 10.0f;
 }
 

--- a/src/tv/TvStateMachine.cpp
+++ b/src/tv/TvStateMachine.cpp
@@ -2,6 +2,9 @@
 
 #include "TvStateMachine.h"
 
+#include <string>
+#include <vector>
+
 namespace InsomniaTV {
 
 TvStateMachine::TvStateMachine(SensorManager& sensorManager,
@@ -60,7 +63,8 @@ bool TvStateMachine::sendPowerCommand(bool on) {
   return true;
 }
 
-void TvStateMachine::setPowerCommandCallback(std::function<void(bool)> callback) {
+void TvStateMachine::setPowerCommandCallback(
+    std::function<void(bool)> callback) {
   std::lock_guard<std::mutex> lock(mutex_);
   powerCommandCallback_ = callback;
 }

--- a/src/tv/TvStateMachine.cpp
+++ b/src/tv/TvStateMachine.cpp
@@ -1,0 +1,145 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#include "TvStateMachine.h"
+
+namespace InsomniaTV {
+
+TvStateMachine::TvStateMachine(SensorManager& sensorManager,
+                                int hysteresisCount)
+    : sensorManager_(sensorManager),
+      hysteresisCount_(hysteresisCount),
+      currentState_(PowerState::UNKNOWN),
+      consecutiveVotes_(0),
+      lastVote_(PowerState::UNKNOWN) {
+  sensorManager_.subscribeValueChange(
+      [this](const std::string& id, bool value) {
+        this->onSensorUpdate(id, value);
+      });
+}
+
+void TvStateMachine::begin(const JsonDocument& config) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  detectionSensors_.clear();
+  sensorValues_.clear();
+  consecutiveVotes_ = 0;
+  lastVote_ = PowerState::UNKNOWN;
+  currentState_ = PowerState::UNKNOWN;
+
+  if (config["hysteresis_count"].is<int>()) {
+    hysteresisCount_ = config["hysteresis_count"].as<int>();
+  }
+
+  JsonArrayConst arr = config["detection_sensors"].as<JsonArrayConst>();
+  if (!arr.isNull()) {
+    for (JsonObjectConst sc : arr) {
+      SensorConfig cfg;
+      cfg.sensorId = sc["sensor_id"] | "";
+      cfg.weight = sc["weight"] | 1;
+      cfg.enabled = sc["enabled"] | true;
+      if (!cfg.sensorId.empty()) {
+        detectionSensors_.push_back(cfg);
+      }
+    }
+  }
+}
+
+TvStateMachine::PowerState TvStateMachine::getPowerState() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return currentState_;
+}
+
+bool TvStateMachine::sendPowerCommand(bool on) {
+  std::function<void(bool)> cb;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!powerCommandCallback_) return false;
+    currentState_ = PowerState::TRANSITIONING;
+    cb = powerCommandCallback_;
+  }
+  cb(on);
+  return true;
+}
+
+void TvStateMachine::setPowerCommandCallback(std::function<void(bool)> callback) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  powerCommandCallback_ = callback;
+}
+
+void TvStateMachine::subscribe(std::function<void(PowerState)> callback) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  subscribers_.push_back(callback);
+}
+
+std::vector<TvStateMachine::SensorContribution>
+TvStateMachine::getContributions() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::vector<SensorContribution> result;
+  for (const auto& sc : detectionSensors_) {
+    SensorContribution contrib;
+    contrib.sensorId = sc.sensorId;
+    contrib.enabled = sc.enabled;
+    auto it = sensorValues_.find(sc.sensorId);
+    contrib.available = (it != sensorValues_.end());
+    contrib.rawValue = contrib.available ? it->second : false;
+    contrib.weightedVote =
+        (sc.enabled && contrib.available)
+            ? sc.weight * (contrib.rawValue ? +1 : -1)
+            : 0;
+    result.push_back(contrib);
+  }
+  return result;
+}
+
+void TvStateMachine::onSensorUpdate(const std::string& sensorId, bool value) {
+  PowerState newState;
+  bool changed = false;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    sensorValues_[sensorId] = value;
+    changed = evaluateState();
+    newState = currentState_;
+  }
+  if (changed) {
+    for (auto& cb : subscribers_) cb(newState);
+  }
+}
+
+float TvStateMachine::calculateConfidence() const {
+  int votes = 0;
+  int maxVotes = 0;
+  for (const auto& sc : detectionSensors_) {
+    if (!sc.enabled) continue;
+    auto it = sensorValues_.find(sc.sensorId);
+    if (it == sensorValues_.end()) continue;
+    votes += sc.weight * (it->second ? +1 : -1);
+    maxVotes += sc.weight;
+  }
+  if (maxVotes == 0) return 0.0f;
+  return static_cast<float>(votes) / maxVotes * 10.0f;
+}
+
+bool TvStateMachine::evaluateState() {
+  float confidence = calculateConfidence();
+
+  PowerState vote = PowerState::UNKNOWN;
+  if (confidence > 3.0f) {
+    vote = PowerState::ON;
+  } else if (confidence < -3.0f) {
+    vote = PowerState::OFF;
+  }
+
+  if (vote == lastVote_) {
+    consecutiveVotes_++;
+  } else {
+    lastVote_ = vote;
+    consecutiveVotes_ = 1;
+  }
+
+  if (consecutiveVotes_ >= hysteresisCount_ && vote != currentState_) {
+    currentState_ = vote;
+    return true;
+  }
+  return false;
+}
+
+}  // namespace InsomniaTV

--- a/src/tv/TvStateMachine.h
+++ b/src/tv/TvStateMachine.h
@@ -1,0 +1,97 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#ifndef SRC_TV_TVSTATEMACHINE_H_
+#define SRC_TV_TVSTATEMACHINE_H_
+
+#include <ArduinoJson.h>
+
+#include <functional>
+#include <map>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "../sensors/SensorManager.h"
+
+namespace InsomniaTV {
+
+/**
+ * @brief Determines TV power state by fusing readings from multiple sensors.
+ *
+ * Each registered detection sensor casts a weighted vote (+weight when its
+ * read() is true, -weight when false).  Aggregated confidence is scaled to
+ * [-10, +10].  A configurable hysteresis count prevents flapping.
+ *
+ * Confidence thresholds:
+ *   > +3  → ON
+ *   < -3  → OFF
+ *   else  → UNKNOWN
+ */
+class TvStateMachine {
+ public:
+  enum class PowerState { UNKNOWN, ON, OFF, TRANSITIONING };
+
+  struct SensorConfig {
+    std::string sensorId;
+    int weight;   // 1-5; higher = more influence
+    bool enabled;
+  };
+
+  struct SensorContribution {
+    std::string sensorId;
+    bool rawValue;
+    int weightedVote;  // weight * (+1 or -1); 0 when disabled or no reading
+    bool enabled;
+    bool available;    // false when no reading has been received yet
+  };
+
+  explicit TvStateMachine(SensorManager& sensorManager,
+                          int hysteresisCount = 2);
+
+  // Load detection sensor list from JSON config.
+  // Expected shape: {"hysteresis_count": 2,
+  //                  "detection_sensors": [{"sensor_id":"..","weight":3,"enabled":true}]}
+  void begin(const JsonDocument& config);
+
+  PowerState getPowerState() const;
+
+  // Send a power on/off command via the registered callback.
+  // Sets state to TRANSITIONING while the command is in flight.
+  // Returns false if no power command callback has been set.
+  bool sendPowerCommand(bool on);
+
+  // Register a callback for power-command delivery (IR, UPnP, etc.)
+  void setPowerCommandCallback(std::function<void(bool)> callback);
+
+  void subscribe(std::function<void(PowerState)> callback);
+
+  // Snapshot of each sensor's current contribution for UI / debug.
+  std::vector<SensorContribution> getContributions() const;
+
+  // Called by SensorManager when a sensor value changes.
+  void onSensorUpdate(const std::string& sensorId, bool value);
+
+ private:
+  // Returns true if the current state changed (caller must hold mutex_).
+  bool evaluateState();
+  float calculateConfidence() const;  // caller must hold mutex_
+
+  SensorManager& sensorManager_;
+  int hysteresisCount_;
+
+  PowerState currentState_;
+  int consecutiveVotes_;
+  PowerState lastVote_;
+
+  std::vector<SensorConfig> detectionSensors_;
+  std::map<std::string, bool> sensorValues_;
+
+  std::vector<std::function<void(PowerState)>> subscribers_;
+  std::function<void(bool)> powerCommandCallback_;
+
+  mutable std::mutex mutex_;
+};
+
+}  // namespace InsomniaTV
+
+#endif  // SRC_TV_TVSTATEMACHINE_H_

--- a/src/tv/TvStateMachine.h
+++ b/src/tv/TvStateMachine.h
@@ -28,12 +28,12 @@ namespace InsomniaTV {
  *   else  → UNKNOWN
  */
 class TvStateMachine {
- public:
+public:
   enum class PowerState { UNKNOWN, ON, OFF, TRANSITIONING };
 
   struct SensorConfig {
     std::string sensorId;
-    int weight;   // 1-5; higher = more influence
+    int weight;  // 1-5; higher = more influence
     bool enabled;
   };
 
@@ -42,7 +42,7 @@ class TvStateMachine {
     bool rawValue;
     int weightedVote;  // weight * (+1 or -1); 0 when disabled or no reading
     bool enabled;
-    bool available;    // false when no reading has been received yet
+    bool available;  // false when no reading has been received yet
   };
 
   explicit TvStateMachine(SensorManager& sensorManager,
@@ -71,7 +71,7 @@ class TvStateMachine {
   // Called by SensorManager when a sensor value changes.
   void onSensorUpdate(const std::string& sensorId, bool value);
 
- private:
+private:
   // Returns true if the current state changed (caller must hold mutex_).
   bool evaluateState();
   float calculateConfidence() const;  // caller must hold mutex_

--- a/src/tv/TvStateMachine.h
+++ b/src/tv/TvStateMachine.h
@@ -49,8 +49,8 @@ class TvStateMachine {
                           int hysteresisCount = 2);
 
   // Load detection sensor list from JSON config.
-  // Expected shape: {"hysteresis_count": 2,
-  //                  "detection_sensors": [{"sensor_id":"..","weight":3,"enabled":true}]}
+  // Expected: {"hysteresis_count":2,
+  //            "detection_sensors":[{"sensor_id":"..","weight":3,"enabled":true}]}
   void begin(const JsonDocument& config);
 
   PowerState getPowerState() const;

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -457,38 +457,29 @@ function wzShowPage(n) {
 function wzStartScan() {
     wzShowPage(2);
     document.getElementById('wz-tv-list').innerHTML = '';
-    document.getElementById('wz-scan-status').innerHTML =
-        '<span class=”spinner”></span>Scanning network&hellip;' +
-        '&nbsp;<a href=”#” style=”font-size:13px;color:#aaa” onclick=”wzStartScan();return false”>Rescan</a>';
+    document.getElementById('wz-scan-status').innerHTML = '<span class=”spinner”></span>Scanning network&hellip;';
     fetch('/api/scan', {method:'POST'});
     wzPollCount = 0;
     wzPoll();
 }
 function wzPoll() {
     wzPollCount++;
-    fetch('/api/discovery').then(r => r.json()).then(all => {
-        // Filter out non-TV devices (media servers, NAS, etc.)
-        const tvs = all.filter(d =>
-            !d.name.toLowerCase().includes('server') &&
-            !d.model.toLowerCase().startsWith('dms') &&
-            !d.model.toLowerCase().startsWith('nas')
-        );
+    fetch('/api/discovery').then(r => r.json()).then(tvs => {
         if (tvs.length) {
             wzShowTvList(tvs);
         } else if (wzPollCount < 8) {
             wzPollTimer = setTimeout(wzPoll, 2000);
         } else {
-            document.getElementById('wz-scan-status').innerHTML =
-                'No smart TVs found. &nbsp;<a href=”#” onclick=”wzStartScan();return false”>Rescan</a>';
+            document.getElementById('wz-scan-status').innerHTML = 'No smart TVs found.';
             document.getElementById('wz-tv-list').innerHTML =
-                '<p style=”color:#888;font-size:14px”>Make sure your TV is on and connected to the same Wi-Fi.</p>';
+                '<p style=”color:#888;font-size:14px”>Make sure your TV is on and connected to the same network. ' +
+                '<a href=”#” onclick=”wzStartScan();return false”>Try again</a></p>';
         }
     });
 }
 function wzShowTvList(tvs) {
     document.getElementById('wz-scan-status').innerHTML =
-        tvs.length + ' TV' + (tvs.length > 1 ? 's' : '') + ' found &mdash; select yours:' +
-        '&nbsp;<a href=”#” style=”font-size:13px;color:#888” onclick=”wzStartScan();return false”>Rescan</a>';
+        tvs.length + ' TV' + (tvs.length > 1 ? 's' : '') + ' found &mdash; select yours:';
     const list = document.getElementById('wz-tv-list');
     list.innerHTML = '';
     tvs.forEach(tv => {
@@ -512,9 +503,9 @@ function wzSelectTv(tv, card) {
 function wzBuildSensors(tv) {
     const slug = tv.name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '').substring(0, 16) || 'tv';
     wzSensors = [
-        {id:slug+'_ping', type:'ping', target_ip:tv.ip,   label:'Ping', desc:'Network reachability \xb7 '+tv.ip,        enabled:true},
-        {id:slug+'_upnp', type:'upnp', target_name:tv.name,label:'UPnP', desc:'Service discovery \xb7 '+tv.name,         enabled:true},
-        {id:slug+'_http', type:'http', url:'http://'+tv.ip+':8001/api/v2/', label:'HTTP', desc:'Samsung SmartThings API', enabled:false},
+        {id: slug+'_ping', type:'ping',  target_ip:   tv.ip,   label:'Ping', desc:'Network reachability · '+tv.ip, enabled:true},
+        {id: slug+'_upnp', type:'upnp',  target_name: tv.name, label:'UPnP', desc:'Service discovery · '+tv.name, enabled:true},
+        {id: slug+'_http', type:'http',  url:'http://'+tv.ip+':8001/api/v2/', label:'HTTP', desc:'Samsung SmartThings API (optional)', enabled:false},
     ];
     const list = document.getElementById('wz-sensor-list');
     list.innerHTML = '';
@@ -522,45 +513,22 @@ function wzBuildSensors(tv) {
         const row = document.createElement('div');
         row.className = 'sensor-preview-row';
         row.innerHTML =
-            '<input type=”checkbox” id=”wsen'+i+'” '+(s.enabled?'checked':'')+
-            ' onchange=”wzSensors['+i+'].enabled=this.checked”>'+
-            '<span class=”s-badge '+s.type+'”>'+s.label+'</span>'+
-            '<div class=”s-id-wrap”>'+
-            '<input type=”text” value=”'+s.id+'” oninput=”wzSensors['+i+'].id=this.value”>'+
-            '<div class=”s-desc”>'+s.desc+'</div></div>';
+            '<input type=”checkbox” id=”wsen' + i + '” ' + (s.enabled ? 'checked' : '') +
+            ' onchange=”wzSensors[' + i + '].enabled=this.checked”>' +
+            '<span class=”s-badge ' + s.type + '”>' + s.label + '</span>' +
+            '<div class=”s-id-wrap”>' +
+            '<input type=”text” value=”' + s.id + '” oninput=”wzSensors[' + i + '].id=this.value”>' +
+            '<div class=”s-desc”>' + s.desc + '</div></div>';
         list.appendChild(row);
     });
 }
-function wzProbeAll() {
-    wzSensors.forEach((s, i) => wzProbeOne(s, i));
-}
-function wzProbeOne(s, i) {
-    const el = document.getElementById('wprobe-' + i);
-    if (!el) return;
-    el.innerHTML = '<span class=”spinner”></span>';
-    const p = {type: s.type};
-    if (s.type === 'ping') p.target_ip   = s.target_ip;
-    if (s.type === 'upnp') p.target_name = s.target_name;
-    if (s.type === 'http') p.url         = s.url;
-    fetch('/api/probe', {method:'POST', headers:{'Content-Type':'application/json','Authorization':'Basic '+btoa('admin:insomnia')}, body:JSON.stringify(p)})
-        .then(r => r.json())
-        .then(d => {
-            const ms = d.latency_ms >= 0 ? ' ' + d.latency_ms + 'ms' : '';
-            el.textContent = d.available ? ('🟢' + ms) : '🔴 fail';
-        })
-        .catch(() => { el.textContent = '🔴 err'; });
-}
 function wzBack() {
-    if (wzPage === 3) {
-        wzShowPage(2);
-        if (wzTv) {
-            document.querySelectorAll('.tv-card').forEach(c => {
-                if (c.querySelector('.tv-name') && c.querySelector('.tv-name').textContent === wzTv.name)
-                    c.classList.add('selected');
-            });
-        }
-    } else if (wzPage === 2) {
-        wzShowPage(1);
+    wzShowPage(2);
+    if (wzTv) {
+        document.querySelectorAll('.tv-card').forEach(c => {
+            if (c.querySelector('.tv-name') && c.querySelector('.tv-name').textContent === wzTv.name)
+                c.classList.add('selected');
+        });
     }
 }
 async function wzCreate() {

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -104,16 +104,18 @@ void WebServer::setupRoutes() {
         .tv-icon { font-size:32px; line-height:1; }
         .tv-name { font-weight:bold; font-size:15px; }
         .tv-meta { color:#777; font-size:13px; margin-top:2px; }
-        .sensor-preview-row { display:flex; align-items:center; gap:8px; padding:9px 10px; border:1px solid #e8e8e8; border-radius:6px; margin:6px 0; background:#fafafa; }
-        .sensor-preview-row input[type=checkbox] { width:auto; margin:0; flex-shrink:0; }
-        .s-badge { font-size:11px; padding:2px 7px; border-radius:10px; background:#e0e0e0; color:#555; white-space:nowrap; }
+        .sensor-preview-row { display:flex; align-items:flex-start; gap:10px; padding:12px; border:1px solid #e8e8e8; border-radius:6px; margin:6px 0; background:#fafafa; }
+        .sensor-preview-row input[type=checkbox] { width:auto; margin:3px 0 0; flex-shrink:0; }
+        .s-preview-body { flex:1; min-width:0; }
+        .s-preview-header { display:flex; justify-content:space-between; align-items:center; margin-bottom:6px; }
+        .s-probe { font-size:13px; color:#555; white-space:nowrap; }
+        .s-badge { font-size:11px; padding:2px 8px; border-radius:10px; background:#e0e0e0; color:#555; white-space:nowrap; font-weight:600; }
         .s-badge.ping { background:#e3f2fd; color:#1565c0; }
         .s-badge.upnp { background:#f3e5f5; color:#6a1b9a; }
         .s-badge.http { background:#e8f5e9; color:#2e7d32; }
-        .s-id-wrap { flex:1; min-width:0; }
-        .s-id-wrap input { padding:4px 6px; font-size:13px; border:1px solid #ccc; border-radius:4px; width:100%; box-sizing:border-box; }
-        .s-desc { color:#999; font-size:11px; margin-top:3px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
-        .spinner { display:inline-block; width:18px; height:18px; border:3px solid #ddd; border-top-color:#4CAF50; border-radius:50%; animation:spin .7s linear infinite; vertical-align:middle; margin-right:8px; }
+        .s-preview-body input[type=text] { width:100%; padding:5px 7px; font-size:13px; border:1px solid #ccc; border-radius:4px; box-sizing:border-box; }
+        .s-desc { color:#999; font-size:11px; margin-top:4px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+        .spinner { display:inline-block; width:14px; height:14px; border:2px solid #ddd; border-top-color:#4CAF50; border-radius:50%; animation:spin .7s linear infinite; vertical-align:middle; }
         @keyframes spin { to { transform:rotate(360deg); } }
         .btn-tv { background:#1565c0; }
         .btn-gray { background:#757575; }
@@ -527,14 +529,14 @@ function wzBuildSensors(tv) {
         row.innerHTML =
             '<input type=”checkbox” id=”wsen'+i+'” '+(s.enabled?'checked':'')+
             ' onchange=”wzSensors['+i+'].enabled=this.checked”>'+
-            '<span class=”s-badge '+s.type+'”>'+s.label+'</span>'+
-            '<div class=”s-id-wrap”>'+
+            '<div class=”s-preview-body”>'+
+              '<div class=”s-preview-header”>'+
+                '<span class=”s-badge '+s.type+'”>'+s.label+'</span>'+
+                '<span id=”wprobe-'+i+'” class=”s-probe”><span class=”spinner”></span></span>'+
+              '</div>'+
               '<input type=”text” value=”'+s.id+'” oninput=”wzSensors['+i+'].id=this.value”>'+
               '<div class=”s-desc”>'+s.desc+'</div>'+
-            '</div>'+
-            '<span id=”wprobe-'+i+'” style=”min-width:72px;text-align:right;font-size:13px;flex-shrink:0”>'+
-              '<span class=”spinner”></span>'+
-            '</span>';
+            '</div>';
         list.appendChild(row);
     });
 }

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -8,6 +8,7 @@
 
 #if defined(ARDUINO)
 #include <AsyncEventSource.h>
+#include <AsyncJson.h>
 #include <ESP32Ping.h>
 #include <HTTPClient.h>
 #include <Update.h>
@@ -95,7 +96,8 @@ void WebServer::setupRoutes() {
         .wz-dot.done { background:#81c784; color:#fff; }
         .wz-line { flex:1; height:2px; background:#ddd; max-width:48px; transition:.3s; }
         .wz-line.done { background:#81c784; }
-        .wz-footer { display:flex; gap:8px; justify-content:flex-end; margin-top:20px; padding-top:15px; border-top:1px solid #eee; }
+        .wz-footer { display:flex; gap:8px; justify-content:space-between; align-items:center; margin-top:20px; padding-top:15px; border-top:1px solid #eee; }
+        .wz-footer-right { display:flex; gap:8px; }
         .tv-card { border:2px solid #ddd; border-radius:8px; padding:12px 16px; margin:8px 0; cursor:pointer; display:flex; align-items:center; gap:14px; transition:.15s; }
         .tv-card:hover { border-color:#4CAF50; background:#f9fff9; }
         .tv-card.selected { border-color:#4CAF50; background:#e8f5e9; }
@@ -115,7 +117,13 @@ void WebServer::setupRoutes() {
         @keyframes spin { to { transform:rotate(360deg); } }
         .btn-tv { background:#1565c0; }
         .btn-gray { background:#757575; }
+        .btn-danger { background:#c62828; }
         .done-icon { font-size:52px; display:block; text-align:center; margin:10px 0 6px; }
+        .sensor-detail-row td { padding:0; border-bottom:2px solid #4CAF50; }
+        .sensor-detail-inner { padding:12px 14px; background:#f9fff9; display:flex; flex-wrap:wrap; gap:10px; align-items:flex-end; }
+        .sensor-detail-inner label { display:block; font-size:12px; font-weight:bold; color:#555; margin-bottom:3px; }
+        .sensor-detail-inner input[type=text] { width:220px; padding:6px 8px; border:1px solid #bbb; border-radius:4px; font-size:13px; }
+        .sensor-detail-inner .detail-field { display:flex; flex-direction:column; }
     </style>
 </head>
 <body>
@@ -227,11 +235,13 @@ void WebServer::setupRoutes() {
     </div>
 
     <div class="wz-footer">
-      <button id="wbtn-cancel" class="btn-gray" onclick="closeWizard()">Cancel</button>
-      <button id="wbtn-back"   class="btn-gray" style="display:none" onclick="wzBack()">&#8592; Back</button>
-      <button id="wbtn-scan"   class="btn-tv"   onclick="wzStartScan()">Start Scan</button>
-      <button id="wbtn-add"    class="btn-tv"   style="display:none" onclick="wzCreate()">Add to Sensors &#8594;</button>
-      <button id="wbtn-done"   style="display:none" onclick="closeWizard();loadSensors()">Done</button>
+      <button id="wbtn-cancel" class="btn-danger" onclick="closeWizard()">Cancel</button>
+      <div class="wz-footer-right">
+        <button id="wbtn-back" class="btn-gray" style="display:none" onclick="wzBack()">&#8592; Back</button>
+        <button id="wbtn-scan" class="btn-tv"   onclick="wzStartScan()">Start Scan</button>
+        <button id="wbtn-add"  class="btn-tv"   style="display:none" onclick="wzCreate()">Add to Sensors &#8594;</button>
+        <button id="wbtn-done" style="display:none" onclick="closeWizard();loadSensors()">Done</button>
+      </div>
     </div>
   </div>
 </div>
@@ -266,22 +276,68 @@ function loadStatus() {
 }
 
 // ── Sensor table ────────────────────────────────────────────────────────────
+let sensorData = {};
 function loadSensors() {
     fetch('/api/sensors').then(r => r.json()).then(data => {
+        sensorData = {};
+        data.forEach(s => { sensorData[s.id] = s; });
         const tbody = document.getElementById('sensor-table-body');
         tbody.innerHTML = '';
         data.forEach(s => {
             const tr = document.createElement('tr');
             tr.id = 'sensor-row-' + s.id;
+            tr.style.cursor = 'pointer';
             tr.innerHTML = `<td>${s.id}</td><td>${s.type}</td><td>${s.value}</td>
               <td>${s.available ? '🟢' : '🔴'}</td>
               <td>
-                <button onclick="testSensor('${s.id}')">Test</button>
-                <button class="delete" onclick="deleteSensor('${s.id}')">Delete</button>
+                <button onclick="event.stopPropagation();testSensor('${s.id}')">Test</button>
+                <button class="delete" onclick="event.stopPropagation();deleteSensor('${s.id}')">Delete</button>
               </td>`;
+            tr.onclick = () => toggleSensorDetail(s.id);
             tbody.appendChild(tr);
         });
     });
+}
+
+// ── Sensor expand/edit ────────────────────────────────────────────────────────
+function toggleSensorDetail(id) {
+    const existing = document.getElementById('sensor-detail-' + id);
+    if (existing) { existing.remove(); return; }
+    const s = sensorData[id];
+    if (!s) return;
+    const fields = buildEditFields(s);
+    const detailTr = document.createElement('tr');
+    detailTr.id = 'sensor-detail-' + id;
+    detailTr.className = 'sensor-detail-row';
+    detailTr.innerHTML = '<td colspan="5"><div class="sensor-detail-inner">' + fields +
+        '<div class="detail-field" style="justify-content:flex-end;padding-bottom:2px">' +
+        '<button onclick="saveSensorEdit(\'' + id + '\')" style="height:32px">Save</button></div>' +
+        '</div></td>';
+    const row = document.getElementById('sensor-row-' + id);
+    row.parentNode.insertBefore(detailTr, row.nextSibling);
+}
+function buildEditFields(s) {
+    let html = '';
+    if (s.type === 'ping') {
+        html += '<div class="detail-field"><label>IP / Hostname</label><input type="text" id="ef-target_ip-'+s.id+'" value="'+(s.target_ip||'')+'"></div>';
+    } else if (s.type === 'http') {
+        html += '<div class="detail-field"><label>URL</label><input type="text" id="ef-url-'+s.id+'" value="'+(s.url||'')+'"></div>';
+    } else if (s.type === 'upnp') {
+        html += '<div class="detail-field"><label>Device Name</label><input type="text" id="ef-target_name-'+s.id+'" value="'+(s.target_name||'')+'"></div>';
+    } else if (s.type === 'gpio_input' || s.type === 'gpio_analog') {
+        html += '<div class="detail-field"><label>Pin</label><input type="text" id="ef-pin-'+s.id+'" value="'+(s.pin!=null?s.pin:'')+'"></div>';
+    }
+    return html;
+}
+function saveSensorEdit(id) {
+    const s = Object.assign({}, sensorData[id]);
+    if (s.type === 'ping')        s.target_ip   = document.getElementById('ef-target_ip-'   + id)?.value || s.target_ip;
+    else if (s.type === 'http')   s.url         = document.getElementById('ef-url-'         + id)?.value || s.url;
+    else if (s.type === 'upnp')   s.target_name = document.getElementById('ef-target_name-' + id)?.value || s.target_name;
+    else if (s.type === 'gpio_input' || s.type === 'gpio_analog')
+                                  s.pin         = +document.getElementById('ef-pin-'         + id)?.value;
+    fetch('/api/sensors', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(s)})
+        .then(() => { document.getElementById('sensor-detail-' + id)?.remove(); loadSensors(); });
 }
 
 // ── Add-sensor modal ─────────────────────────────────────────────────────────
@@ -395,7 +451,6 @@ function wzShowPage(n) {
         dot.className = 'wz-dot' + (i < n ? ' done' : i === n ? ' active' : '');
         if (i < 4) document.getElementById('wl' + i).className = 'wz-line' + (i < n ? ' done' : '');
     });
-    document.getElementById('wbtn-cancel').style.display = n < 4 ? '' : 'none';
     document.getElementById('wbtn-back').style.display   = (n === 2 || n === 3) ? '' : 'none';
     document.getElementById('wbtn-scan').style.display   = n === 1 ? '' : 'none';
     document.getElementById('wbtn-add').style.display    = n === 3 ? '' : 'none';
@@ -582,6 +637,12 @@ document.getElementsByClassName('tablinks')[0].click();
       obj["type"] = sensor->getType();
       obj["available"] = sensor->isAvailable();
       obj["value"] = sensor->read();
+      JsonDocument cfg = sensor->getConfig();
+      for (JsonPair kv : cfg.as<JsonObject>()) {
+        const char* k = kv.key().c_str();
+        if (strcmp(k, "id") != 0 && strcmp(k, "type") != 0)
+          obj[k] = kv.value();
+      }
     }
     String response;
     serializeJson(doc, response);
@@ -704,72 +765,50 @@ document.getElementsByClassName('tablinks')[0].click();
       });
 
   // One-shot sensor probe without registering it in SensorManager.
-  // Runs blocking network calls in a dedicated task so the async web server
-  // is not stalled.
+  // Uses AsyncCallbackJsonWebHandler so the body is fully accumulated before
+  // our handler is called — avoids the deferred-send race with _send().
   _server.on(
       "/api/probe", HTTP_POST,
-      [](AsyncWebServerRequest* request) {
+      [this](AsyncWebServerRequest* request, JsonVariant& json) {
         if (!request->authenticate("admin", "insomnia")) {
           return request->requestAuthentication();
         }
-      },
-      NULL,
-      [this](AsyncWebServerRequest* request, uint8_t* data, size_t len,
-             size_t index, size_t total) {
-        JsonDocument doc;
-        deserializeJson(doc, data, len);
+        std::string type = json["type"] | "";
+        bool available = false;
+        int latencyMs = -1;
 
-        struct ProbeCtx {
-          AsyncWebServerRequest* req;
-          std::string type;
-          std::string target;   // ip for ping, friendly name for upnp
-          std::string url;      // for http
-          SamsungTvDiscovery* discovery;
-        };
-        auto* ctx = new ProbeCtx;
-        ctx->req = request;
-        ctx->type = doc["type"] | "";
-        ctx->target = ctx->type == "ping"
-                          ? std::string(doc["target_ip"] | "")
-                          : std::string(doc["target_name"] | "");
-        ctx->url = doc["url"] | "";
-        ctx->discovery = &_discovery;
+        if (type == "ping") {
+          std::string target = json["target_ip"] | "";
+          if (!target.empty()) {
+            uint32_t t = millis();
+            available = Ping.ping(target.c_str(), 1);
+            latencyMs = static_cast<int>(millis() - t);
+          }
+        } else if (type == "http") {
+          std::string url = json["url"] | "";
+          if (!url.empty()) {
+            HTTPClient http;
+            http.begin(url.c_str());
+            http.setTimeout(3000);
+            uint32_t t = millis();
+            int code = http.GET();
+            latencyMs = static_cast<int>(millis() - t);
+            available = (code > 0 && code < 500);
+            http.end();
+          }
+        } else if (type == "upnp") {
+          std::string target = json["target_name"] | "";
+          for (auto& tv : _discovery.getDiscoveredTvs()) {
+            if (tv.name == target) { available = true; break; }
+          }
+          latencyMs = 0;
+        }
 
-        xTaskCreate(
-            [](void* arg) {
-              auto* ctx = static_cast<ProbeCtx*>(arg);
-              bool available = false;
-              int latencyMs = -1;
-
-              if (ctx->type == "ping" && !ctx->target.empty()) {
-                uint32_t t = millis();
-                available = Ping.ping(ctx->target.c_str(), 1);
-                latencyMs = static_cast<int>(millis() - t);
-              } else if (ctx->type == "http" && !ctx->url.empty()) {
-                HTTPClient http;
-                http.begin(ctx->url.c_str());
-                http.setTimeout(3000);
-                uint32_t t = millis();
-                int code = http.GET();
-                latencyMs = static_cast<int>(millis() - t);
-                available = (code > 0 && code < 500);
-                http.end();
-              } else if (ctx->type == "upnp") {
-                for (auto& tv : ctx->discovery->getDiscoveredTvs()) {
-                  if (tv.name == ctx->target) { available = true; break; }
-                }
-                latencyMs = 0;
-              }
-
-              char buf[80];
-              snprintf(buf, sizeof(buf),
-                       "{\"available\":%s,\"latency_ms\":%d}",
-                       available ? "true" : "false", latencyMs);
-              ctx->req->send(200, "application/json", buf);
-              delete ctx;
-              vTaskDelete(NULL);
-            },
-            "probe_task", 6144, ctx, 1, NULL);
+        char buf[80];
+        snprintf(buf, sizeof(buf),
+                 "{\"available\":%s,\"latency_ms\":%d}",
+                 available ? "true" : "false", latencyMs);
+        request->send(200, "application/json", buf);
       });
 
   _server.on("/api/scan", HTTP_POST, [this](AsyncWebServerRequest* request) {

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -469,7 +469,12 @@ function wzStartScan() {
 }
 function wzPoll() {
     wzPollCount++;
-    fetch('/api/discovery').then(r => r.json()).then(tvs => {
+    fetch('/api/discovery').then(r => r.json()).then(all => {
+        const tvs = all.filter(d =>
+            !d.name.toLowerCase().includes('server') &&
+            !d.model.toLowerCase().startsWith('dms') &&
+            !d.model.toLowerCase().startsWith('nas')
+        );
         if (tvs.length) {
             wzShowTvList(tvs);
         } else if (wzPollCount < 8) {

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -96,8 +96,7 @@ void WebServer::setupRoutes() {
         .wz-dot.done { background:#81c784; color:#fff; }
         .wz-line { flex:1; height:2px; background:#ddd; max-width:48px; transition:.3s; }
         .wz-line.done { background:#81c784; }
-        .wz-footer { display:flex; gap:8px; justify-content:space-between; align-items:center; margin-top:20px; padding-top:15px; border-top:1px solid #eee; }
-        .wz-footer-right { display:flex; gap:8px; }
+        .wz-footer { display:flex; gap:8px; justify-content:flex-end; margin-top:20px; padding-top:15px; border-top:1px solid #eee; }
         .tv-card { border:2px solid #ddd; border-radius:8px; padding:12px 16px; margin:8px 0; cursor:pointer; display:flex; align-items:center; gap:14px; transition:.15s; }
         .tv-card:hover { border-color:#90caf9; background:#e3f2fd; }
         .tv-card.selected { border-color:#4CAF50; background:#e8f5e9; }
@@ -117,7 +116,6 @@ void WebServer::setupRoutes() {
         @keyframes spin { to { transform:rotate(360deg); } }
         .btn-tv { background:#1565c0; }
         .btn-gray { background:#757575; }
-        .btn-danger { background:#c62828; }
         .done-icon { font-size:52px; display:block; text-align:center; margin:10px 0 6px; }
         .sensor-detail-row td { padding:0; border-bottom:2px solid #4CAF50; }
         .sensor-detail-inner { padding:12px 14px; background:#f9fff9; display:flex; flex-wrap:wrap; gap:10px; align-items:flex-end; }
@@ -235,13 +233,11 @@ void WebServer::setupRoutes() {
     </div>
 
     <div class="wz-footer">
-      <button id="wbtn-cancel" class="btn-danger" onclick="closeWizard()">Cancel</button>
-      <div class="wz-footer-right">
-        <button id="wbtn-back" class="btn-gray" style="display:none" onclick="wzBack()">&#8592; Back</button>
-        <button id="wbtn-scan" class="btn-tv"   onclick="wzStartScan()">Start Scan</button>
-        <button id="wbtn-add"  class="btn-tv"   style="display:none" onclick="wzCreate()">Add to Sensors &#8594;</button>
-        <button id="wbtn-done" style="display:none" onclick="closeWizard();loadSensors()">Done</button>
-      </div>
+      <button id="wbtn-cancel" class="btn-gray"  onclick="closeWizard()">Cancel</button>
+      <button id="wbtn-back"   class="btn-gray"  style="display:none" onclick="wzBack()">&#8592; Back</button>
+      <button id="wbtn-scan"   class="btn-tv"    onclick="wzStartScan()">Start Scan</button>
+      <button id="wbtn-add"    class="btn-tv"    style="display:none" onclick="wzCreate()">Add to Sensors &#8594;</button>
+      <button id="wbtn-done"   style="display:none" onclick="closeWizard();loadSensors()">Done</button>
     </div>
   </div>
 </div>
@@ -451,7 +447,8 @@ function wzShowPage(n) {
         dot.className = 'wz-dot' + (i < n ? ' done' : i === n ? ' active' : '');
         if (i < 4) document.getElementById('wl' + i).className = 'wz-line' + (i < n ? ' done' : '');
     });
-    document.getElementById('wbtn-back').style.display   = (n === 2 || n === 3) ? '' : 'none';
+    document.getElementById('wbtn-cancel').style.display = n < 4 ? '' : 'none';
+    document.getElementById('wbtn-back').style.display   = n === 3 ? '' : 'none';
     document.getElementById('wbtn-scan').style.display   = n === 1 ? '' : 'none';
     document.getElementById('wbtn-add').style.display    = n === 3 ? '' : 'none';
     document.getElementById('wbtn-done').style.display   = n === 4 ? '' : 'none';

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -176,6 +176,7 @@ function openTab(evt, tabName) {
 
 function loadSensors() {
     fetch('/api/sensors').then(r => r.json()).then(data => {
+        console.log('Sensors loaded:', data);
         const tbody = document.getElementById('sensor-table-body');
         tbody.innerHTML = '';
         data.forEach(s => {
@@ -184,6 +185,8 @@ function loadSensors() {
             tr.innerHTML = `<td>${s.id}</td><td>${s.type}</td><td>${s.value}</td><td>${s.available ? '🟢' : '🔴'}</td>`;
             tbody.appendChild(tr);
         });
+    }).catch(err => {
+        console.error('Error loading sensors:', err);
     });
 }
 

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -107,10 +107,11 @@ void WebServer::setupRoutes() {
         .s-badge.ping { background:#e3f2fd; color:#1565c0; }
         .s-badge.upnp { background:#f3e5f5; color:#6a1b9a; }
         .s-badge.http { background:#e8f5e9; color:#2e7d32; }
-        .wz-srow { display:flex; align-items:center; gap:10px; padding:8px 12px; border:1px solid #ddd; border-radius:6px; margin:5px 0; background:#fafafa; }
-        .wz-srow input[type=checkbox] { width:auto; flex-shrink:0; margin:0; }
-        .wz-srow .wz-sid { flex:1; min-width:0; width:auto; box-sizing:border-box; padding:5px 8px; font-size:13px; border:1px solid #ccc; border-radius:4px; }
-        .wz-sdesc { color:#888; font-size:12px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; flex-shrink:1; max-width:180px; }
+        .wz-srow { display:flex; align-items:center; gap:10px; padding:10px 14px; border:1px solid #e0e0e0; border-radius:6px; margin:5px 0; background:#fafafa; }
+        .wz-srow input[type=checkbox] { width:auto; flex-shrink:0; margin:0; cursor:pointer; }
+        .wz-srow-info { flex:1; min-width:0; overflow:hidden; }
+        .wz-srow-name { font-size:13px; color:#333; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+        .wz-srow-id { font-size:11px; color:#aaa; margin-top:2px; font-family:monospace; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
         .spinner { display:inline-block; width:18px; height:18px; border:3px solid #ddd; border-top-color:#4CAF50; border-radius:50%; animation:spin .7s linear infinite; vertical-align:middle; margin-right:8px; }
         @keyframes spin { to { transform:rotate(360deg); } }
         .btn-tv { background:#1565c0; }
@@ -515,8 +516,10 @@ function wzBuildSensors(tv) {
             '<input type=”checkbox” id=”wsen' + i + '” ' + (s.enabled ? 'checked' : '') +
             ' onchange=”wzSensors[' + i + '].enabled=this.checked”>' +
             '<span class=”s-badge ' + s.type + '”>' + s.label + '</span>' +
-            '<input type=”text” class=”wz-sid” value=”' + s.id + '” oninput=”wzSensors[' + i + '].id=this.value”>' +
-            '<span class=”wz-sdesc”>' + s.desc + '</span>';
+            '<div class=”wz-srow-info”>' +
+            '<div class=”wz-srow-name”>' + s.desc + '</div>' +
+            '<div class=”wz-srow-id”>' + s.id + '</div>' +
+            '</div>';
         list.appendChild(row);
     });
 }

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -270,6 +270,10 @@ function renderDiscovery(data) {
 }
 // Default open Status tab
 document.getElementsByClassName('tablinks')[0].click();
+// Trigger sensors load if it's the active tab
+if (document.getElementsByClassName('tablinks')[2].classList.contains('active')) {
+    loadSensors();
+}
 </script>
 
 </body>

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -1,7 +1,10 @@
 // Copyright 2026 insomniaTV Contributors. All rights reserved.
 
 #include "WebServer.h"
+
 #include <ArduinoJson.h>
+
+#include <cstdio>
 #include <string>
 
 #include "../version.h"
@@ -656,7 +659,8 @@ document.getElementsByClassName('tablinks')[0].click();
     request->send(200, "application/json", "{\"status\":\"ok\"}");
   });
 
-  _server.on("/api/sensors", HTTP_DELETE, [this](AsyncWebServerRequest* request) {
+  _server.on("/api/sensors", HTTP_DELETE,
+      [this](AsyncWebServerRequest* request) {
     if (!request->authenticate("admin", "insomnia")) {
       return request->requestAuthentication();
     }
@@ -680,7 +684,7 @@ document.getElementsByClassName('tablinks')[0].click();
       _configMgr.set(cfg);
       _configMgr.save();
 
-      // For now, simple re-init (might need a clear() in SensorManager if instances linger)
+      // Re-init so the running SensorManager reflects the updated config.
       SensorManager::instance().init(cfg.sensorsJson, _discovery);
 
       request->send(200, "application/json", "{\"status\":\"ok\"}");
@@ -771,7 +775,10 @@ document.getElementsByClassName('tablinks')[0].click();
         } else if (type == "upnp") {
           std::string target = json["target_name"] | "";
           for (auto& tv : _discovery.getDiscoveredTvs()) {
-            if (tv.name == target) { available = true; break; }
+            if (tv.name == target) {
+              available = true;
+              break;
+            }
           }
           latencyMs = 0;
         }

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -237,10 +237,16 @@ function updateFormFields() {
     } else if (type === 'upnp') {
         fields.innerHTML = `
             <label>Select Device:</label>
-            <div id="upnp-list" style="border: 1px solid #ccc; max-height: 100px; overflow-y: auto;">Scanning...</div>
+            <div id="upnp-list" style="border: 1px solid #ccc; max-height: 100px; overflow-y: auto; margin-bottom: 10px;">Scanning...</div>
+            <button type="button" onclick="scanTVForModal()" style="width: 100%; margin-bottom: 10px; background: #2196F3;">Scan Network</button>
             <input type="hidden" id="s_target_name">`;
         fetchUpnpDevices();
     }
+}
+
+function scanTVForModal() {
+    document.getElementById('upnp-list').innerHTML = '<div class="discovery-item">Scanning...</div>';
+    fetch('/api/scan', {method: 'POST'}).then(() => setTimeout(fetchUpnpDevices, 3000));
 }
 
 function fetchUpnpDevices() {

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -104,17 +104,16 @@ void WebServer::setupRoutes() {
         .tv-icon { font-size:32px; line-height:1; }
         .tv-name { font-weight:bold; font-size:15px; }
         .tv-meta { color:#777; font-size:13px; margin-top:2px; }
-        .s3-sensor { margin:5px 0 8px; }
-        .s3-row { display:flex; align-items:center; gap:8px; padding:8px 12px; background:#fafafa; border:1px solid #ddd; border-radius:6px 6px 0 0; }
-        .s3-check { flex-shrink:0; width:15px !important; height:15px; margin:0; cursor:pointer; accent-color:#4CAF50; }
-        .s-badge { font-size:11px; padding:2px 8px; border-radius:10px; background:#e0e0e0; color:#555; white-space:nowrap; font-weight:600; flex-shrink:0; }
+        .sensor-preview-row { display:flex; align-items:center; gap:8px; padding:9px 10px; border:1px solid #e8e8e8; border-radius:6px; margin:6px 0; background:#fafafa; }
+        .sensor-preview-row input[type=checkbox] { width:auto; margin:0; flex-shrink:0; }
+        .s-badge { font-size:11px; padding:2px 7px; border-radius:10px; background:#e0e0e0; color:#555; white-space:nowrap; }
         .s-badge.ping { background:#e3f2fd; color:#1565c0; }
         .s-badge.upnp { background:#f3e5f5; color:#6a1b9a; }
         .s-badge.http { background:#e8f5e9; color:#2e7d32; }
-        .s3-id { flex:1 1 0 !important; width:0 !important; min-width:0; padding:4px 7px !important; font-size:13px; border:1px solid #ddd; border-radius:4px; box-sizing:border-box; }
-        .s3-status { flex-shrink:0; width:72px; text-align:right; font-size:13px; color:#444; white-space:nowrap; }
-        .s3-desc { font-size:11px; color:#888; padding:3px 12px 5px; background:#fafafa; border:1px solid #ddd; border-top:none; border-radius:0 0 6px 6px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-        .spinner { display:inline-block; width:14px; height:14px; border:2px solid #ddd; border-top-color:#4CAF50; border-radius:50%; animation:spin .7s linear infinite; vertical-align:middle; }
+        .s-id-wrap { flex:1; min-width:0; }
+        .s-id-wrap input { padding:4px 6px; font-size:13px; border:1px solid #ccc; border-radius:4px; width:100%; box-sizing:border-box; }
+        .s-desc { color:#999; font-size:11px; margin-top:3px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+        .spinner { display:inline-block; width:18px; height:18px; border:3px solid #ddd; border-top-color:#4CAF50; border-radius:50%; animation:spin .7s linear infinite; vertical-align:middle; margin-right:8px; }
         @keyframes spin { to { transform:rotate(360deg); } }
         .btn-tv { background:#1565c0; }
         .btn-gray { background:#757575; }
@@ -511,7 +510,7 @@ function wzSelectTv(tv, card) {
     wzTv = tv;
     document.querySelectorAll('.tv-card').forEach(c => c.classList.remove('selected'));
     card.classList.add('selected');
-    setTimeout(() => { wzBuildSensors(tv); wzShowPage(3); wzProbeAll(); }, 250);
+    setTimeout(() => { wzBuildSensors(tv); wzShowPage(3); }, 250);
 }
 function wzBuildSensors(tv) {
     const slug = tv.name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '').substring(0, 16) || 'tv';
@@ -523,18 +522,16 @@ function wzBuildSensors(tv) {
     const list = document.getElementById('wz-sensor-list');
     list.innerHTML = '';
     wzSensors.forEach((s, i) => {
-        const wrap = document.createElement('div');
-        wrap.className = 's3-sensor';
-        wrap.innerHTML =
-            '<div class=”s3-row”>'+
-              '<input type=”checkbox” class=”s3-check” id=”wsen'+i+'” '+(s.enabled?'checked':'')+
-              ' onchange=”wzSensors['+i+'].enabled=this.checked”>'+
-              '<span class=”s-badge '+s.type+'”>'+s.label+'</span>'+
-              '<input type=”text” class=”s3-id” value=”'+s.id+'” oninput=”wzSensors['+i+'].id=this.value”>'+
-              '<span id=”wprobe-'+i+'” class=”s3-status”><span class=”spinner”></span></span>'+
-            '</div>'+
-            '<div class=”s3-desc”>'+s.desc+'</div>';
-        list.appendChild(wrap);
+        const row = document.createElement('div');
+        row.className = 'sensor-preview-row';
+        row.innerHTML =
+            '<input type=”checkbox” id=”wsen'+i+'” '+(s.enabled?'checked':'')+
+            ' onchange=”wzSensors['+i+'].enabled=this.checked”>'+
+            '<span class=”s-badge '+s.type+'”>'+s.label+'</span>'+
+            '<div class=”s-id-wrap”>'+
+            '<input type=”text” value=”'+s.id+'” oninput=”wzSensors['+i+'].id=this.value”>'+
+            '<div class=”s-desc”>'+s.desc+'</div></div>';
+        list.appendChild(row);
     });
 }
 function wzProbeAll() {

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -58,6 +58,7 @@ void WebServer::setupRoutes() {
 <!DOCTYPE html>
 <html>
 <head>
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>insomniaTV</title>
     <style>
@@ -73,24 +74,52 @@ void WebServer::setupRoutes() {
         th, td { border: 1px solid #ddd; padding: 12px; text-align: left; }
         tr:nth-child(even) { background-color: #f9f9f9; }
         button { cursor: pointer; padding: 8px 12px; border: none; border-radius: 4px; background: #4CAF50; color: white; }
-        button:hover { background: #45a049; }
+        button:hover { opacity: .88; }
         button.delete { background: #f44336; }
-        button.delete:hover { background: #da190b; }
         .modal { display:none; position:fixed; z-index:100; left:0; top:0; width:100%; height:100%; background-color:rgba(0,0,0,0.5); }
-        .modal-content { background-color:#fefefe; margin:10% auto; padding:25px; border:1px solid #888; width:80%; max-width: 500px; border-radius: 8px; }
-        .close { float:right; cursor:pointer; font-size: 24px; }
-        label { display: block; margin: 10px 0 5px; font-weight: bold; }
-        input[type=text], input[type=number], select { width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box; }
-        .discovery-item { padding: 8px; border-bottom: 1px solid #eee; cursor: pointer; }
-        .discovery-item:hover { background: #f0f0f0; }
+        .modal-content { background-color:#fefefe; margin:10% auto; padding:25px; border:1px solid #888; width:80%; max-width:500px; border-radius:8px; }
+        .close { float:right; cursor:pointer; font-size:24px; line-height:1; }
+        label { display:block; margin:10px 0 5px; font-weight:bold; }
+        input[type=text], input[type=number], select { width:100%; padding:8px; border:1px solid #ccc; border-radius:4px; box-sizing:border-box; }
+        .discovery-item { padding:8px; border-bottom:1px solid #eee; cursor:pointer; }
+        .discovery-item:hover { background:#f0f0f0; }
+        /* ── Wizard ───────────────────────────────────────────────── */
+        .wizard-modal { max-width:560px; }
+        .wz-progress { display:flex; align-items:center; justify-content:center; margin:4px 0 22px; gap:4px; }
+        .wz-dot { width:26px; height:26px; border-radius:50%; background:#ddd; color:#aaa; display:flex; align-items:center; justify-content:center; font-size:12px; font-weight:bold; flex-shrink:0; transition:.3s; }
+        .wz-dot.active { background:#4CAF50; color:#fff; }
+        .wz-dot.done { background:#81c784; color:#fff; }
+        .wz-line { flex:1; height:2px; background:#ddd; max-width:48px; transition:.3s; }
+        .wz-line.done { background:#81c784; }
+        .wz-footer { display:flex; gap:8px; justify-content:flex-end; margin-top:20px; padding-top:15px; border-top:1px solid #eee; }
+        .tv-card { border:2px solid #ddd; border-radius:8px; padding:12px 16px; margin:8px 0; cursor:pointer; display:flex; align-items:center; gap:14px; transition:.15s; }
+        .tv-card:hover { border-color:#4CAF50; background:#f9fff9; }
+        .tv-card.selected { border-color:#4CAF50; background:#e8f5e9; }
+        .tv-icon { font-size:32px; line-height:1; }
+        .tv-name { font-weight:bold; font-size:15px; }
+        .tv-meta { color:#777; font-size:13px; margin-top:2px; }
+        .sensor-preview-row { display:flex; align-items:center; gap:8px; padding:9px 10px; border:1px solid #e8e8e8; border-radius:6px; margin:6px 0; background:#fafafa; }
+        .sensor-preview-row input[type=checkbox] { width:auto; margin:0; flex-shrink:0; }
+        .s-badge { font-size:11px; padding:2px 7px; border-radius:10px; background:#e0e0e0; color:#555; white-space:nowrap; }
+        .s-badge.ping { background:#e3f2fd; color:#1565c0; }
+        .s-badge.upnp { background:#f3e5f5; color:#6a1b9a; }
+        .s-badge.http { background:#e8f5e9; color:#2e7d32; }
+        .s-id-wrap { flex:1; min-width:0; }
+        .s-id-wrap input { padding:4px 6px; font-size:13px; border:1px solid #ccc; border-radius:4px; width:100%; box-sizing:border-box; }
+        .s-desc { color:#999; font-size:11px; margin-top:3px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+        .spinner { display:inline-block; width:18px; height:18px; border:3px solid #ddd; border-top-color:#4CAF50; border-radius:50%; animation:spin .7s linear infinite; vertical-align:middle; margin-right:8px; }
+        @keyframes spin { to { transform:rotate(360deg); } }
+        .btn-tv { background:#1565c0; }
+        .btn-gray { background:#757575; }
+        .done-icon { font-size:52px; display:block; text-align:center; margin:10px 0 6px; }
     </style>
 </head>
 <body>
 
 <div class="tab">
-  <button class="tablinks" onclick="openTab(event, 'Status')">Status</button>
-  <button class="tablinks" onclick="openTab(event, 'Config')">Config</button>
-  <button class="tablinks" onclick="openTab(event, 'Sensors')">Sensors</button>
+  <button class="tablinks" onclick="openTab(event,'Status')">Status</button>
+  <button class="tablinks" onclick="openTab(event,'Config')">Config</button>
+  <button class="tablinks" onclick="openTab(event,'Sensors')">Sensors</button>
 </div>
 
 <div id="Status" class="tabcontent">
@@ -117,80 +146,122 @@ void WebServer::setupRoutes() {
 
 <div id="Sensors" class="tabcontent">
   <h3>Sensor Registry</h3>
-  <button onclick="openModal()" style="margin-bottom: 15px;">Add New Sensor</button>
+  <div style="display:flex;gap:8px;margin-bottom:15px;flex-wrap:wrap;">
+    <button class="btn-tv" onclick="openWizard()">&#128250; Add Smart TV</button>
+    <button onclick="openModal()">+ Add Sensor</button>
+  </div>
   <table>
     <thead>
-      <tr>
-        <th>ID</th>
-        <th>Type</th>
-        <th>Value</th>
-        <th>Status</th>
-        <th>Actions</th>
-      </tr>
+      <tr><th>ID</th><th>Type</th><th>Value</th><th>Status</th><th>Actions</th></tr>
     </thead>
-    <tbody id="sensor-table-body">
-    </tbody>
+    <tbody id="sensor-table-body"></tbody>
   </table>
 </div>
 
+<!-- ── Add Sensor modal ─────────────────────────────────────────── -->
 <div id="sensorModal" class="modal">
   <div class="modal-content">
     <span onclick="closeModal()" class="close">&times;</span>
     <h3>Add Sensor</h3>
-    <form id="sensorForm">
-      <label>Unique ID:</label>
-      <input type="text" id="sensorId" placeholder="e.g., room_motion" required>
+    <label>Unique ID:</label>
+    <input type="text" id="sensorId" placeholder="e.g., room_motion" required>
+    <label>Sensor Type:</label>
+    <select id="sensorType" onchange="updateFormFields()">
+      <option value="gpio_input">GPIO Input (Digital)</option>
+      <option value="gpio_analog">GPIO Analog (ADC)</option>
+      <option value="ping">Ping (ICMP)</option>
+      <option value="http">HTTP (GET)</option>
+      <option value="upnp">UPnP (Discovery)</option>
+    </select>
+    <div id="dynamicFields"></div>
+    <button type="button" onclick="saveSensor()" style="margin-top:20px;width:100%;">Save Sensor</button>
+  </div>
+</div>
 
-      <label>Sensor Type:</label>
-      <select id="sensorType" onchange="updateFormFields()">
-        <option value="gpio_input">GPIO Input (Digital)</option>
-        <option value="gpio_analog">GPIO Analog (ADC)</option>
-        <option value="ping">Ping (ICMP)</option>
-        <option value="http">HTTP (GET)</option>
-        <option value="upnp">UPnP (Discovery)</option>
-      </select>
+<!-- ── Add Smart TV wizard ──────────────────────────────────────── -->
+<div id="tvWizardModal" class="modal">
+  <div class="modal-content wizard-modal">
+    <span onclick="closeWizard()" class="close">&times;</span>
+    <h3 style="margin-top:0">&#128250; Add Smart TV</h3>
 
-      <div id="dynamicFields"></div>
+    <div class="wz-progress">
+      <div class="wz-dot active" id="wd1">1</div>
+      <div class="wz-line" id="wl1"></div>
+      <div class="wz-dot" id="wd2">2</div>
+      <div class="wz-line" id="wl2"></div>
+      <div class="wz-dot" id="wd3">3</div>
+      <div class="wz-line" id="wl3"></div>
+      <div class="wz-dot" id="wd4">&#10003;</div>
+    </div>
 
-      <button type="button" onclick="saveSensor()" style="margin-top: 20px; width: 100%;">Save Sensor</button>
-    </form>
+    <!-- Step 1: intro / scan -->
+    <div id="wpage1">
+      <h4 style="margin-top:0">Scan Your Network</h4>
+      <p>Click <b>Start Scan</b> to search your network for smart TVs. Samsung, Sony, LG and other UPnP-enabled TVs will be detected automatically.</p>
+      <p style="color:#888;font-size:13px">Make sure your TV is powered on and connected to the same Wi-Fi network.</p>
+    </div>
+
+    <!-- Step 2: results -->
+    <div id="wpage2" style="display:none">
+      <h4 style="margin-top:0">Select Your TV</h4>
+      <div id="wz-scan-status"><span class="spinner"></span>Scanning network&hellip;</div>
+      <div id="wz-tv-list"></div>
+    </div>
+
+    <!-- Step 3: sensor preview -->
+    <div id="wpage3" style="display:none">
+      <h4 style="margin-top:0">Sensors to Create</h4>
+      <p style="color:#555;font-size:14px;margin-top:0">The following sensors will monitor your TV. Edit the IDs or uncheck any you don&apos;t need.</p>
+      <div id="wz-sensor-list"></div>
+    </div>
+
+    <!-- Step 4: done -->
+    <div id="wpage4" style="display:none;text-align:center;padding:10px 0 6px">
+      <span class="done-icon">&#9989;</span>
+      <h4 id="wz-done-title" style="margin:4px 0 8px"></h4>
+      <p id="wz-done-msg" style="color:#666;margin:0"></p>
+    </div>
+
+    <div class="wz-footer">
+      <button id="wbtn-cancel" class="btn-gray" onclick="closeWizard()">Cancel</button>
+      <button id="wbtn-back"   class="btn-gray" style="display:none" onclick="wzBack()">&#8592; Back</button>
+      <button id="wbtn-scan"   class="btn-tv"   onclick="wzStartScan()">Start Scan</button>
+      <button id="wbtn-add"    class="btn-tv"   style="display:none" onclick="wzCreate()">Add to Sensors &#8594;</button>
+      <button id="wbtn-done"   style="display:none" onclick="closeWizard();loadSensors()">Done</button>
+    </div>
   </div>
 </div>
 
 <script>
+// ── SSE live updates ────────────────────────────────────────────────────────
 const source = new EventSource('/events');
 source.addEventListener('sensor_update', function(e) {
-    const data = JSON.parse(e.data);
-    const row = document.getElementById('sensor-row-' + data.id);
-    if (row) {
-        row.cells[2].textContent = data.value;
-        row.cells[3].textContent = data.available ? '🟢' : '🔴';
-    }
+    const d = JSON.parse(e.data);
+    const row = document.getElementById('sensor-row-' + d.id);
+    if (row) { row.cells[2].textContent = d.value; row.cells[3].textContent = d.available ? '🟢' : '🔴'; }
 }, false);
 
-function openTab(evt, tabName) {
-    var i, tabcontent, tablinks;
-    tabcontent = document.getElementsByClassName("tabcontent");
-    for (i = 0; i < tabcontent.length; i++) { tabcontent[i].style.display = "none"; }
-    tablinks = document.getElementsByClassName("tablinks");
-    for (i = 0; i < tablinks.length; i++) { tablinks[i].className = tablinks[i].className.replace(" active", ""); }
-
-    document.getElementById(tabName).style.display = "block";
-    evt.currentTarget.className += " active";
-
-    if (tabName === 'Status') loadStatus();
-    if (tabName === 'Sensors') loadSensors();
+// ── Tab routing ─────────────────────────────────────────────────────────────
+function openTab(evt, name) {
+    document.querySelectorAll('.tabcontent').forEach(t => t.style.display = 'none');
+    document.querySelectorAll('.tablinks').forEach(b => b.classList.remove('active'));
+    document.getElementById(name).style.display = 'block';
+    evt.currentTarget.classList.add('active');
+    if (name === 'Status')  loadStatus();
+    if (name === 'Sensors') loadSensors();
 }
 
+// ── Status ──────────────────────────────────────────────────────────────────
 function loadStatus() {
     fetch('/api/status').then(r => r.json()).then(data => {
-        for (const [key, value] of Object.entries(data)) {
-            const el = document.getElementById('sys-' + key);
-            if (el) el.textContent = value;
+        for (const [k, v] of Object.entries(data)) {
+            const el = document.getElementById('sys-' + k);
+            if (el) el.textContent = v;
         }
     });
 }
 
+// ── Sensor table ────────────────────────────────────────────────────────────
 function loadSensors() {
     fetch('/api/sensors').then(r => r.json()).then(data => {
         const tbody = document.getElementById('sensor-table-body');
@@ -198,137 +269,226 @@ function loadSensors() {
         data.forEach(s => {
             const tr = document.createElement('tr');
             tr.id = 'sensor-row-' + s.id;
-            tr.innerHTML = `
-                <td>${s.id}</td>
-                <td>${s.type}</td>
-                <td>${s.value}</td>
-                <td>${s.available ? '🟢' : '🔴'}</td>
-                <td>
-                    <button onclick="testSensor('${s.id}')">Test</button>
-                    <button class="delete" onclick="deleteSensor('${s.id}')">Delete</button>
-                </td>`;
+            tr.innerHTML = `<td>${s.id}</td><td>${s.type}</td><td>${s.value}</td>
+              <td>${s.available ? '🟢' : '🔴'}</td>
+              <td>
+                <button onclick="testSensor('${s.id}')">Test</button>
+                <button class="delete" onclick="deleteSensor('${s.id}')">Delete</button>
+              </td>`;
             tbody.appendChild(tr);
         });
     });
 }
 
-function openModal() { document.getElementById('sensorModal').style.display = 'block'; updateFormFields(); }
+// ── Add-sensor modal ─────────────────────────────────────────────────────────
+function openModal()  { document.getElementById('sensorModal').style.display = 'block'; updateFormFields(); }
 function closeModal() { document.getElementById('sensorModal').style.display = 'none'; }
 
 function updateFormFields() {
     const type = document.getElementById('sensorType').value;
-    const fields = document.getElementById('dynamicFields');
-    fields.innerHTML = '';
-
+    const f = document.getElementById('dynamicFields');
+    f.innerHTML = '';
     if (type === 'gpio_input') {
-        fields.innerHTML = `
-            <label>Pin Number:</label><input type="number" id="s_pin" value="0">
-            <label>Pullup:</label><input type="checkbox" id="s_pullup" checked>
-            <label>Debounce (ms):</label><input type="number" id="s_debounce" value="50">`;
+        f.innerHTML = `<label>Pin:</label><input type="number" id="s_pin" value="0">
+          <label>Pullup:</label><input type="checkbox" id="s_pullup" checked>
+          <label>Debounce (ms):</label><input type="number" id="s_debounce" value="50">`;
     } else if (type === 'gpio_analog') {
-        fields.innerHTML = `
-            <label>Pin Number:</label><input type="number" id="s_pin" value="0">
-            <label>Scale:</label><input type="number" id="s_scale" step="0.001" value="1.0">
-            <label>Offset:</label><input type="number" id="s_offset" step="0.001" value="0.0">`;
+        f.innerHTML = `<label>Pin:</label><input type="number" id="s_pin" value="0">
+          <label>Scale:</label><input type="number" id="s_scale" step="0.001" value="1.0">
+          <label>Offset:</label><input type="number" id="s_offset" step="0.001" value="0.0">`;
     } else if (type === 'ping') {
-        fields.innerHTML = `<label>Target IP/Host:</label><input type="text" id="s_target" placeholder="192.168.1.1">`;
+        f.innerHTML = `<label>Target IP/Host:</label><input type="text" id="s_target" placeholder="192.168.1.1">`;
     } else if (type === 'http') {
-        fields.innerHTML = `<label>URL:</label><input type="text" id="s_url" placeholder="http://api.local/status">`;
+        f.innerHTML = `<label>URL:</label><input type="text" id="s_url" placeholder="http://api.local/status">`;
     } else if (type === 'upnp') {
-        fields.innerHTML = `
-            <label>Select Device:</label>
-            <div id="upnp-list" style="border: 1px solid #ccc; max-height: 100px; overflow-y: auto; margin-bottom: 10px;">Scanning...</div>
-            <button type="button" onclick="scanTVForModal()" style="width: 100%; margin-bottom: 10px; background: #2196F3;">Scan Network</button>
-            <input type="hidden" id="s_target_name">`;
+        f.innerHTML = `<label>Select Device:</label>
+          <div id="upnp-list" style="border:1px solid #ccc;max-height:100px;overflow-y:auto;margin-bottom:10px;">Scanning...</div>
+          <button type="button" onclick="scanTVForModal()" style="width:100%;margin-bottom:10px;background:#2196F3;">Scan Network</button>
+          <input type="hidden" id="s_target_name">`;
         fetchUpnpDevices();
     }
 }
-
 function scanTVForModal() {
     document.getElementById('upnp-list').innerHTML = '<div class="discovery-item">Scanning...</div>';
-    fetch('/api/scan', {method: 'POST'}).then(() => setTimeout(fetchUpnpDevices, 3000));
+    fetch('/api/scan', {method:'POST'}).then(() => setTimeout(fetchUpnpDevices, 3000));
 }
-
 function fetchUpnpDevices() {
     fetch('/api/discovery').then(r => r.json()).then(data => {
         const list = document.getElementById('upnp-list');
         list.innerHTML = '';
-        if (data.length === 0) list.innerHTML = '<div class="discovery-item">No TVs found. Scan in Config tab first.</div>';
+        if (!data.length) { list.innerHTML = '<div class="discovery-item">No TVs found.</div>'; return; }
         data.forEach(tv => {
             const div = document.createElement('div');
             div.className = 'discovery-item';
-            div.textContent = `${tv.name} (${tv.ip})`;
+            div.textContent = tv.name + ' (' + tv.ip + ')';
             div.onclick = () => {
                 document.getElementById('s_target_name').value = tv.name;
-                Array.from(list.children).forEach(c => c.style.background = '');
+                list.querySelectorAll('.discovery-item').forEach(c => c.style.background = '');
                 div.style.background = '#e0e0e0';
             };
             list.appendChild(div);
         });
     });
 }
-
 function saveSensor() {
     const id = document.getElementById('sensorId').value;
     const type = document.getElementById('sensorType').value;
-    if (!id) return alert('ID is required');
-
-    const config = { id, type };
-    if (type === 'gpio_input') {
-        config.pin = parseInt(document.getElementById('s_pin').value);
-        config.pullup = document.getElementById('s_pullup').checked;
-        config.debounce_ms = parseInt(document.getElementById('s_debounce').value);
-    } else if (type === 'gpio_analog') {
-        config.pin = parseInt(document.getElementById('s_pin').value);
-        config.scale = parseFloat(document.getElementById('s_scale').value);
-        config.offset = parseFloat(document.getElementById('s_offset').value);
-    } else if (type === 'ping') {
-        config.target_ip = document.getElementById('s_target').value;
-    } else if (type === 'http') {
-        config.url = document.getElementById('s_url').value;
-    } else if (type === 'upnp') {
-        config.target_name = document.getElementById('s_target_name').value;
-    }
-
-    fetch('/api/sensors', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(config)
-    }).then(r => {
-        if (r.ok) { closeModal(); loadSensors(); }
-        else alert('Failed to save');
-    });
+    if (!id) { alert('ID is required'); return; }
+    const cfg = {id, type};
+    if (type === 'gpio_input')  { cfg.pin = +document.getElementById('s_pin').value; cfg.pullup = document.getElementById('s_pullup').checked; cfg.debounce_ms = +document.getElementById('s_debounce').value; }
+    else if (type === 'gpio_analog') { cfg.pin = +document.getElementById('s_pin').value; cfg.scale = +document.getElementById('s_scale').value; cfg.offset = +document.getElementById('s_offset').value; }
+    else if (type === 'ping')   { cfg.target_ip = document.getElementById('s_target').value; }
+    else if (type === 'http')   { cfg.url = document.getElementById('s_url').value; }
+    else if (type === 'upnp')   { cfg.target_name = document.getElementById('s_target_name').value; }
+    fetch('/api/sensors', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(cfg)})
+      .then(r => { if (r.ok) { closeModal(); loadSensors(); } else alert('Failed to save'); });
 }
-
 function deleteSensor(id) {
     if (!confirm('Delete sensor ' + id + '?')) return;
-    fetch('/api/sensors?id=' + id, { method: 'DELETE' }).then(() => loadSensors());
+    fetch('/api/sensors?id=' + id, {method:'DELETE'}).then(() => loadSensors());
 }
-
 function testSensor(id) {
-    fetch('/api/sensors/test', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-        body: 'id=' + id
-    }).then(r => r.json()).then(data => {
-        alert('Test result for ' + data.id + ': ' + (data.value ? 'HIGH/OK' : 'LOW/FAIL'));
-    });
+    fetch('/api/sensors/test', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:'id='+id})
+      .then(r => r.json()).then(d => alert('Test: ' + d.id + ' = ' + (d.value ? 'HIGH / OK' : 'LOW / FAIL')));
 }
 
+// ── Config tab ───────────────────────────────────────────────────────────────
 function scanTV() {
     document.getElementById('tv-list').innerHTML = '<li>Scanning...</li>';
-    fetch('/api/scan', {method: 'POST'}).then(() => setTimeout(loadDiscovery, 3000));
+    fetch('/api/scan', {method:'POST'}).then(() => setTimeout(loadDiscovery, 3000));
 }
 function loadDiscovery() {
     fetch('/api/discovery').then(r => r.json()).then(data => {
-        let list = document.getElementById('tv-list');
+        const list = document.getElementById('tv-list');
         list.innerHTML = '';
         data.forEach(tv => {
-            let li = document.createElement('li');
-            li.innerHTML = `<b>${tv.name}</b> (${tv.ip}) - ${tv.model}`;
+            const li = document.createElement('li');
+            li.innerHTML = '<b>' + tv.name + '</b> (' + tv.ip + ') - ' + tv.model;
             list.appendChild(li);
         });
     });
+}
+
+// ── Add Smart TV wizard ──────────────────────────────────────────────────────
+let wzTv = null, wzSensors = [], wzPage = 1, wzPollTimer = null, wzPollCount = 0;
+
+function openWizard() {
+    wzTv = null; wzSensors = []; wzPage = 1; wzPollCount = 0;
+    if (wzPollTimer) { clearTimeout(wzPollTimer); wzPollTimer = null; }
+    document.getElementById('tvWizardModal').style.display = 'block';
+    wzShowPage(1);
+}
+function closeWizard() {
+    if (wzPollTimer) { clearTimeout(wzPollTimer); wzPollTimer = null; }
+    document.getElementById('tvWizardModal').style.display = 'none';
+}
+
+function wzShowPage(n) {
+    wzPage = n;
+    [1,2,3,4].forEach(i => {
+        document.getElementById('wpage' + i).style.display = i === n ? 'block' : 'none';
+        const dot = document.getElementById('wd' + i);
+        dot.className = 'wz-dot' + (i < n ? ' done' : i === n ? ' active' : '');
+        if (i < 4) document.getElementById('wl' + i).className = 'wz-line' + (i < n ? ' done' : '');
+    });
+    document.getElementById('wbtn-cancel').style.display = n < 4 ? '' : 'none';
+    document.getElementById('wbtn-back').style.display   = n === 3 ? '' : 'none';
+    document.getElementById('wbtn-scan').style.display   = n === 1 ? '' : 'none';
+    document.getElementById('wbtn-add').style.display    = n === 3 ? '' : 'none';
+    document.getElementById('wbtn-done').style.display   = n === 4 ? '' : 'none';
+}
+
+function wzStartScan() {
+    wzShowPage(2);
+    document.getElementById('wz-tv-list').innerHTML = '';
+    document.getElementById('wz-scan-status').innerHTML = '<span class="spinner"></span>Scanning network&hellip;';
+    fetch('/api/scan', {method:'POST'});
+    wzPollCount = 0;
+    wzPoll();
+}
+function wzPoll() {
+    wzPollCount++;
+    fetch('/api/discovery').then(r => r.json()).then(tvs => {
+        if (tvs.length) {
+            wzShowTvList(tvs);
+        } else if (wzPollCount < 8) {
+            wzPollTimer = setTimeout(wzPoll, 2000);
+        } else {
+            document.getElementById('wz-scan-status').innerHTML = 'No smart TVs found.';
+            document.getElementById('wz-tv-list').innerHTML =
+                '<p style="color:#888;font-size:14px">Make sure your TV is on and connected to the same network. ' +
+                '<a href="#" onclick="wzStartScan();return false">Try again</a></p>';
+        }
+    });
+}
+function wzShowTvList(tvs) {
+    document.getElementById('wz-scan-status').innerHTML =
+        tvs.length + ' TV' + (tvs.length > 1 ? 's' : '') + ' found &mdash; select yours:';
+    const list = document.getElementById('wz-tv-list');
+    list.innerHTML = '';
+    tvs.forEach(tv => {
+        const card = document.createElement('div');
+        card.className = 'tv-card';
+        card.innerHTML =
+            '<div class="tv-icon">&#128250;</div>' +
+            '<div style="flex:1"><div class="tv-name">' + tv.name + '</div>' +
+            '<div class="tv-meta">' + (tv.model || 'Smart TV') + ' &nbsp;&middot;&nbsp; ' + tv.ip + '</div></div>' +
+            '<span style="color:#bbb;font-size:20px">&#8250;</span>';
+        card.onclick = () => wzSelectTv(tv, card);
+        list.appendChild(card);
+    });
+}
+function wzSelectTv(tv, card) {
+    wzTv = tv;
+    document.querySelectorAll('.tv-card').forEach(c => c.classList.remove('selected'));
+    card.classList.add('selected');
+    setTimeout(() => { wzBuildSensors(tv); wzShowPage(3); }, 250);
+}
+function wzBuildSensors(tv) {
+    const slug = tv.name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '').substring(0, 16) || 'tv';
+    wzSensors = [
+        {id: slug+'_ping', type:'ping',  target_ip:   tv.ip,   label:'Ping', desc:'Network reachability · '+tv.ip, enabled:true},
+        {id: slug+'_upnp', type:'upnp',  target_name: tv.name, label:'UPnP', desc:'Service discovery · '+tv.name, enabled:true},
+        {id: slug+'_http', type:'http',  url:'http://'+tv.ip+':8001/api/v2/', label:'HTTP', desc:'Samsung SmartThings API (optional)', enabled:false},
+    ];
+    const list = document.getElementById('wz-sensor-list');
+    list.innerHTML = '';
+    wzSensors.forEach((s, i) => {
+        const row = document.createElement('div');
+        row.className = 'sensor-preview-row';
+        row.innerHTML =
+            '<input type="checkbox" id="wsen' + i + '" ' + (s.enabled ? 'checked' : '') +
+            ' onchange="wzSensors[' + i + '].enabled=this.checked">' +
+            '<span class="s-badge ' + s.type + '">' + s.label + '</span>' +
+            '<div class="s-id-wrap">' +
+            '<input type="text" value="' + s.id + '" oninput="wzSensors[' + i + '].id=this.value">' +
+            '<div class="s-desc">' + s.desc + '</div></div>';
+        list.appendChild(row);
+    });
+}
+function wzBack() {
+    wzShowPage(2);
+    if (wzTv) {
+        document.querySelectorAll('.tv-card').forEach(c => {
+            if (c.querySelector('.tv-name') && c.querySelector('.tv-name').textContent === wzTv.name)
+                c.classList.add('selected');
+        });
+    }
+}
+async function wzCreate() {
+    const toCreate = wzSensors.filter(s => s.enabled && s.id.trim());
+    let created = 0;
+    for (const s of toCreate) {
+        const p = {id: s.id.trim(), type: s.type};
+        if (s.type === 'ping') p.target_ip   = s.target_ip;
+        if (s.type === 'upnp') p.target_name = s.target_name;
+        if (s.type === 'http') p.url         = s.url;
+        const r = await fetch('/api/sensors', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(p)});
+        if (r.ok) created++;
+    }
+    document.getElementById('wz-done-title').textContent = created + ' sensor' + (created !== 1 ? 's' : '') + ' added!';
+    document.getElementById('wz-done-msg').textContent   = 'Sensors for “' + wzTv.name + '” are now active in the registry.';
+    wzShowPage(4);
 }
 
 document.getElementsByClassName('tablinks')[0].click();

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -4,6 +4,8 @@
 #include <ArduinoJson.h>
 #include <string>
 
+#include "../version.h"
+
 #if defined(ARDUINO)
 #include <AsyncEventSource.h>
 #include <Update.h>
@@ -392,7 +394,7 @@ function wzShowPage(n) {
         if (i < 4) document.getElementById('wl' + i).className = 'wz-line' + (i < n ? ' done' : '');
     });
     document.getElementById('wbtn-cancel').style.display = n < 4 ? '' : 'none';
-    document.getElementById('wbtn-back').style.display   = n === 3 ? '' : 'none';
+    document.getElementById('wbtn-back').style.display   = (n === 2 || n === 3) ? '' : 'none';
     document.getElementById('wbtn-scan').style.display   = n === 1 ? '' : 'none';
     document.getElementById('wbtn-add').style.display    = n === 3 ? '' : 'none';
     document.getElementById('wbtn-done').style.display   = n === 4 ? '' : 'none';
@@ -401,39 +403,48 @@ function wzShowPage(n) {
 function wzStartScan() {
     wzShowPage(2);
     document.getElementById('wz-tv-list').innerHTML = '';
-    document.getElementById('wz-scan-status').innerHTML = '<span class="spinner"></span>Scanning network&hellip;';
+    document.getElementById('wz-scan-status').innerHTML =
+        '<span class=”spinner”></span>Scanning network&hellip;' +
+        '&nbsp;<a href=”#” style=”font-size:13px;color:#aaa” onclick=”wzStartScan();return false”>Rescan</a>';
     fetch('/api/scan', {method:'POST'});
     wzPollCount = 0;
     wzPoll();
 }
 function wzPoll() {
     wzPollCount++;
-    fetch('/api/discovery').then(r => r.json()).then(tvs => {
+    fetch('/api/discovery').then(r => r.json()).then(all => {
+        // Filter out non-TV devices (media servers, NAS, etc.)
+        const tvs = all.filter(d =>
+            !d.name.toLowerCase().includes('server') &&
+            !d.model.toLowerCase().startsWith('dms') &&
+            !d.model.toLowerCase().startsWith('nas')
+        );
         if (tvs.length) {
             wzShowTvList(tvs);
         } else if (wzPollCount < 8) {
             wzPollTimer = setTimeout(wzPoll, 2000);
         } else {
-            document.getElementById('wz-scan-status').innerHTML = 'No smart TVs found.';
+            document.getElementById('wz-scan-status').innerHTML =
+                'No smart TVs found. &nbsp;<a href=”#” onclick=”wzStartScan();return false”>Rescan</a>';
             document.getElementById('wz-tv-list').innerHTML =
-                '<p style="color:#888;font-size:14px">Make sure your TV is on and connected to the same network. ' +
-                '<a href="#" onclick="wzStartScan();return false">Try again</a></p>';
+                '<p style=”color:#888;font-size:14px”>Make sure your TV is on and connected to the same Wi-Fi.</p>';
         }
     });
 }
 function wzShowTvList(tvs) {
     document.getElementById('wz-scan-status').innerHTML =
-        tvs.length + ' TV' + (tvs.length > 1 ? 's' : '') + ' found &mdash; select yours:';
+        tvs.length + ' TV' + (tvs.length > 1 ? 's' : '') + ' found &mdash; select yours:' +
+        '&nbsp;<a href=”#” style=”font-size:13px;color:#888” onclick=”wzStartScan();return false”>Rescan</a>';
     const list = document.getElementById('wz-tv-list');
     list.innerHTML = '';
     tvs.forEach(tv => {
         const card = document.createElement('div');
         card.className = 'tv-card';
         card.innerHTML =
-            '<div class="tv-icon">&#128250;</div>' +
-            '<div style="flex:1"><div class="tv-name">' + tv.name + '</div>' +
-            '<div class="tv-meta">' + (tv.model || 'Smart TV') + ' &nbsp;&middot;&nbsp; ' + tv.ip + '</div></div>' +
-            '<span style="color:#bbb;font-size:20px">&#8250;</span>';
+            '<div class=”tv-icon”>&#128250;</div>' +
+            '<div style=”flex:1”><div class=”tv-name”>' + tv.name + '</div>' +
+            '<div class=”tv-meta”>' + (tv.model || 'Smart TV') + ' &nbsp;&middot;&nbsp; ' + tv.ip + '</div></div>' +
+            '<span style=”color:#bbb;font-size:20px”>&#8250;</span>';
         card.onclick = () => wzSelectTv(tv, card);
         list.appendChild(card);
     });
@@ -442,14 +453,14 @@ function wzSelectTv(tv, card) {
     wzTv = tv;
     document.querySelectorAll('.tv-card').forEach(c => c.classList.remove('selected'));
     card.classList.add('selected');
-    setTimeout(() => { wzBuildSensors(tv); wzShowPage(3); }, 250);
+    setTimeout(() => { wzBuildSensors(tv); wzShowPage(3); wzProbeAll(); }, 250);
 }
 function wzBuildSensors(tv) {
     const slug = tv.name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '').substring(0, 16) || 'tv';
     wzSensors = [
-        {id: slug+'_ping', type:'ping',  target_ip:   tv.ip,   label:'Ping', desc:'Network reachability · '+tv.ip, enabled:true},
-        {id: slug+'_upnp', type:'upnp',  target_name: tv.name, label:'UPnP', desc:'Service discovery · '+tv.name, enabled:true},
-        {id: slug+'_http', type:'http',  url:'http://'+tv.ip+':8001/api/v2/', label:'HTTP', desc:'Samsung SmartThings API (optional)', enabled:false},
+        {id:slug+'_ping', type:'ping', target_ip:tv.ip,   label:'Ping', desc:'Network reachability \xb7 '+tv.ip,        enabled:true},
+        {id:slug+'_upnp', type:'upnp', target_name:tv.name,label:'UPnP', desc:'Service discovery \xb7 '+tv.name,         enabled:true},
+        {id:slug+'_http', type:'http', url:'http://'+tv.ip+':8001/api/v2/', label:'HTTP', desc:'Samsung SmartThings API', enabled:false},
     ];
     const list = document.getElementById('wz-sensor-list');
     list.innerHTML = '';
@@ -457,22 +468,49 @@ function wzBuildSensors(tv) {
         const row = document.createElement('div');
         row.className = 'sensor-preview-row';
         row.innerHTML =
-            '<input type="checkbox" id="wsen' + i + '" ' + (s.enabled ? 'checked' : '') +
-            ' onchange="wzSensors[' + i + '].enabled=this.checked">' +
-            '<span class="s-badge ' + s.type + '">' + s.label + '</span>' +
-            '<div class="s-id-wrap">' +
-            '<input type="text" value="' + s.id + '" oninput="wzSensors[' + i + '].id=this.value">' +
-            '<div class="s-desc">' + s.desc + '</div></div>';
+            '<input type=”checkbox” id=”wsen'+i+'” '+(s.enabled?'checked':'')+
+            ' onchange=”wzSensors['+i+'].enabled=this.checked”>'+
+            '<span class=”s-badge '+s.type+'”>'+s.label+'</span>'+
+            '<div class=”s-id-wrap”>'+
+              '<input type=”text” value=”'+s.id+'” oninput=”wzSensors['+i+'].id=this.value”>'+
+              '<div class=”s-desc”>'+s.desc+'</div>'+
+            '</div>'+
+            '<span id=”wprobe-'+i+'” style=”min-width:72px;text-align:right;font-size:13px;flex-shrink:0”>'+
+              '<span class=”spinner”></span>'+
+            '</span>';
         list.appendChild(row);
     });
 }
+function wzProbeAll() {
+    wzSensors.forEach((s, i) => wzProbeOne(s, i));
+}
+function wzProbeOne(s, i) {
+    const el = document.getElementById('wprobe-' + i);
+    if (!el) return;
+    el.innerHTML = '<span class=”spinner”></span>';
+    const p = {type: s.type};
+    if (s.type === 'ping') p.target_ip   = s.target_ip;
+    if (s.type === 'upnp') p.target_name = s.target_name;
+    if (s.type === 'http') p.url         = s.url;
+    fetch('/api/probe', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(p)})
+        .then(r => r.json())
+        .then(d => {
+            const ms = d.latency_ms >= 0 ? ' ' + d.latency_ms + 'ms' : '';
+            el.textContent = d.available ? ('🟢' + ms) : '🔴 fail';
+        })
+        .catch(() => { el.textContent = '🔴 err'; });
+}
 function wzBack() {
-    wzShowPage(2);
-    if (wzTv) {
-        document.querySelectorAll('.tv-card').forEach(c => {
-            if (c.querySelector('.tv-name') && c.querySelector('.tv-name').textContent === wzTv.name)
-                c.classList.add('selected');
-        });
+    if (wzPage === 3) {
+        wzShowPage(2);
+        if (wzTv) {
+            document.querySelectorAll('.tv-card').forEach(c => {
+                if (c.querySelector('.tv-name') && c.querySelector('.tv-name').textContent === wzTv.name)
+                    c.classList.add('selected');
+            });
+        }
+    } else if (wzPage === 2) {
+        wzShowPage(1);
     }
 }
 async function wzCreate() {
@@ -661,6 +699,75 @@ document.getElementsByClassName('tablinks')[0].click();
             Update.printError(Serial);
           }
         }
+      });
+
+  // One-shot sensor probe without registering it in SensorManager.
+  // Runs blocking network calls in a dedicated task so the async web server
+  // is not stalled.
+  _server.on(
+      "/api/probe", HTTP_POST,
+      [](AsyncWebServerRequest* request) {
+        if (!request->authenticate("admin", "insomnia")) {
+          return request->requestAuthentication();
+        }
+      },
+      NULL,
+      [this](AsyncWebServerRequest* request, uint8_t* data, size_t len,
+             size_t index, size_t total) {
+        JsonDocument doc;
+        deserializeJson(doc, data, len);
+
+        struct ProbeCtx {
+          AsyncWebServerRequest* req;
+          std::string type;
+          std::string target;   // ip for ping, friendly name for upnp
+          std::string url;      // for http
+          SamsungTvDiscovery* discovery;
+        };
+        auto* ctx = new ProbeCtx;
+        ctx->req = request;
+        ctx->type = doc["type"] | "";
+        ctx->target = ctx->type == "ping"
+                          ? std::string(doc["target_ip"] | "")
+                          : std::string(doc["target_name"] | "");
+        ctx->url = doc["url"] | "";
+        ctx->discovery = &_discovery;
+
+        xTaskCreate(
+            [](void* arg) {
+              auto* ctx = static_cast<ProbeCtx*>(arg);
+              bool available = false;
+              int latencyMs = -1;
+
+              if (ctx->type == "ping" && !ctx->target.empty()) {
+                uint32_t t = millis();
+                available = Ping.ping(ctx->target.c_str(), 1);
+                latencyMs = static_cast<int>(millis() - t);
+              } else if (ctx->type == "http" && !ctx->url.empty()) {
+                HTTPClient http;
+                http.begin(ctx->url.c_str());
+                http.setTimeout(3000);
+                uint32_t t = millis();
+                int code = http.GET();
+                latencyMs = static_cast<int>(millis() - t);
+                available = (code > 0 && code < 500);
+                http.end();
+              } else if (ctx->type == "upnp") {
+                for (auto& tv : ctx->discovery->getDiscoveredTvs()) {
+                  if (tv.name == ctx->target) { available = true; break; }
+                }
+                latencyMs = 0;
+              }
+
+              char buf[80];
+              snprintf(buf, sizeof(buf),
+                       "{\"available\":%s,\"latency_ms\":%d}",
+                       available ? "true" : "false", latencyMs);
+              ctx->req->send(200, "application/json", buf);
+              delete ctx;
+              vTaskDelete(NULL);
+            },
+            "probe_task", 6144, ctx, 1, NULL);
       });
 
   _server.on("/api/scan", HTTP_POST, [this](AsyncWebServerRequest* request) {

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -624,74 +624,80 @@ document.getElementsByClassName('tablinks')[0].click();
     request->send(200, "application/json", response);
   });
 
-  _server.on("/api/sensors", HTTP_POST, [](AsyncWebServerRequest* request) {
-    if (!request->authenticate("admin", "insomnia")) {
-      return request->requestAuthentication();
-    }
-  }, NULL, [this](AsyncWebServerRequest* request, uint8_t* data, size_t len,
-              size_t index, size_t total) {
-    JsonDocument doc;
-    deserializeJson(doc, data, len);
+  _server.on(
+      "/api/sensors", HTTP_POST,
+      [](AsyncWebServerRequest* request) {
+        if (!request->authenticate("admin", "insomnia")) {
+          return request->requestAuthentication();
+        }
+      },
+      NULL,
+      [this](AsyncWebServerRequest* request, uint8_t* data, size_t len,
+             size_t index, size_t total) {
+        JsonDocument doc;
+        deserializeJson(doc, data, len);
 
-    // Save to configuration
-    Config cfg = _configMgr.get();
-    JsonDocument sensorDoc;
-    deserializeJson(sensorDoc, cfg.sensorsJson);
+        // Save to configuration
+        Config cfg = _configMgr.get();
+        JsonDocument sensorDoc;
+        deserializeJson(sensorDoc, cfg.sensorsJson);
 
-    // Check if it already exists to avoid duplicates
-    bool found = false;
-    for (JsonObject s : sensorDoc.as<JsonArray>()) {
-        if (s["id"] == doc["id"]) {
+        // Check if it already exists to avoid duplicates
+        bool found = false;
+        for (JsonObject s : sensorDoc.as<JsonArray>()) {
+          if (s["id"] == doc["id"]) {
             s.set(doc.as<JsonObject>());
             found = true;
             break;
+          }
         }
-    }
-    if (!found) sensorDoc.add(doc);
+        if (!found)
+          sensorDoc.add(doc);
 
-    serializeJson(sensorDoc, cfg.sensorsJson);
-    _configMgr.set(cfg);
-    _configMgr.save();
+        serializeJson(sensorDoc, cfg.sensorsJson);
+        _configMgr.set(cfg);
+        _configMgr.save();
 
-    // Re-register immediately
-    SensorManager::instance().init(cfg.sensorsJson, _discovery);
+        // Re-register immediately
+        SensorManager::instance().init(cfg.sensorsJson, _discovery);
 
-    request->send(200, "application/json", "{\"status\":\"ok\"}");
-  });
+        request->send(200, "application/json", "{\"status\":\"ok\"}");
+      });
 
   _server.on("/api/sensors", HTTP_DELETE,
-      [this](AsyncWebServerRequest* request) {
-    if (!request->authenticate("admin", "insomnia")) {
-      return request->requestAuthentication();
-    }
-    if (request->hasParam("id")) {
-      String id = request->getParam("id")->value();
+             [this](AsyncWebServerRequest* request) {
+               if (!request->authenticate("admin", "insomnia")) {
+                 return request->requestAuthentication();
+               }
+               if (request->hasParam("id")) {
+                 String id = request->getParam("id")->value();
 
-      // Remove from configuration
-      Config cfg = _configMgr.get();
-      JsonDocument sensorDoc;
-      deserializeJson(sensorDoc, cfg.sensorsJson);
+                 // Remove from configuration
+                 Config cfg = _configMgr.get();
+                 JsonDocument sensorDoc;
+                 deserializeJson(sensorDoc, cfg.sensorsJson);
 
-      JsonArray array = sensorDoc.as<JsonArray>();
-      for (size_t i = 0; i < array.size(); i++) {
-          if (array[i]["id"] == id) {
-              array.remove(i);
-              break;
-          }
-      }
+                 JsonArray array = sensorDoc.as<JsonArray>();
+                 for (size_t i = 0; i < array.size(); i++) {
+                   if (array[i]["id"] == id) {
+                     array.remove(i);
+                     break;
+                   }
+                 }
 
-      serializeJson(sensorDoc, cfg.sensorsJson);
-      _configMgr.set(cfg);
-      _configMgr.save();
+                 serializeJson(sensorDoc, cfg.sensorsJson);
+                 _configMgr.set(cfg);
+                 _configMgr.save();
 
-      // Re-init so the running SensorManager reflects the updated config.
-      SensorManager::instance().init(cfg.sensorsJson, _discovery);
+                 // Re-init so the running SensorManager reflects the updated
+                 // config.
+                 SensorManager::instance().init(cfg.sensorsJson, _discovery);
 
-      request->send(200, "application/json", "{\"status\":\"ok\"}");
-      return;
-    }
-    request->send(400);
-  });
+                 request->send(200, "application/json", "{\"status\":\"ok\"}");
+                 return;
+               }
+               request->send(400);
+             });
 
   _server.on(
       "/api/sensors/test", HTTP_POST, [](AsyncWebServerRequest* request) {
@@ -703,8 +709,9 @@ document.getElementsByClassName('tablinks')[0].click();
           auto sensor = SensorManager::instance().getSensor(id.c_str());
           if (sensor) {
             bool result = sensor->read();
-            String response = "{\"id\":\"" + id + "\", \"value\":" +
-                              (result ? "true" : "false") + "}";
+            String response = "{\"id\":\"" + id +
+                              "\", \"value\":" + (result ? "true" : "false") +
+                              "}";
             request->send(200, "application/json", response);
             return;
           }
@@ -743,52 +750,51 @@ document.getElementsByClassName('tablinks')[0].click();
   // One-shot sensor probe without registering it in SensorManager.
   // Uses AsyncCallbackJsonWebHandler so the body is fully accumulated before
   // our handler is called — avoids the deferred-send race with _send().
-  _server.on(
-      "/api/probe", HTTP_POST,
-      [this](AsyncWebServerRequest* request, JsonVariant& json) {
-        if (!request->authenticate("admin", "insomnia")) {
-          return request->requestAuthentication();
-        }
-        std::string type = json["type"] | "";
-        bool available = false;
-        int latencyMs = -1;
+  _server.on("/api/probe", HTTP_POST,
+             [this](AsyncWebServerRequest* request, JsonVariant& json) {
+               if (!request->authenticate("admin", "insomnia")) {
+                 return request->requestAuthentication();
+               }
+               std::string type = json["type"] | "";
+               bool available = false;
+               int latencyMs = -1;
 
-        if (type == "ping") {
-          std::string target = json["target_ip"] | "";
-          if (!target.empty()) {
-            uint32_t t = millis();
-            available = Ping.ping(target.c_str(), 1);
-            latencyMs = static_cast<int>(millis() - t);
-          }
-        } else if (type == "http") {
-          std::string url = json["url"] | "";
-          if (!url.empty()) {
-            HTTPClient http;
-            http.begin(url.c_str());
-            http.setTimeout(3000);
-            uint32_t t = millis();
-            int code = http.GET();
-            latencyMs = static_cast<int>(millis() - t);
-            available = (code > 0 && code < 500);
-            http.end();
-          }
-        } else if (type == "upnp") {
-          std::string target = json["target_name"] | "";
-          for (auto& tv : _discovery.getDiscoveredTvs()) {
-            if (tv.name == target) {
-              available = true;
-              break;
-            }
-          }
-          latencyMs = 0;
-        }
+               if (type == "ping") {
+                 std::string target = json["target_ip"] | "";
+                 if (!target.empty()) {
+                   uint32_t t = millis();
+                   available = Ping.ping(target.c_str(), 1);
+                   latencyMs = static_cast<int>(millis() - t);
+                 }
+               } else if (type == "http") {
+                 std::string url = json["url"] | "";
+                 if (!url.empty()) {
+                   HTTPClient http;
+                   http.begin(url.c_str());
+                   http.setTimeout(3000);
+                   uint32_t t = millis();
+                   int code = http.GET();
+                   latencyMs = static_cast<int>(millis() - t);
+                   available = (code > 0 && code < 500);
+                   http.end();
+                 }
+               } else if (type == "upnp") {
+                 std::string target = json["target_name"] | "";
+                 for (auto& tv : _discovery.getDiscoveredTvs()) {
+                   if (tv.name == target) {
+                     available = true;
+                     break;
+                   }
+                 }
+                 latencyMs = 0;
+               }
 
-        char buf[80];
-        snprintf(buf, sizeof(buf),
-                 "{\"available\":%s,\"latency_ms\":%d}",
-                 available ? "true" : "false", latencyMs);
-        request->send(200, "application/json", buf);
-      });
+               char buf[80];
+               snprintf(buf, sizeof(buf),
+                        "{\"available\":%s,\"latency_ms\":%d}",
+                        available ? "true" : "false", latencyMs);
+               request->send(200, "application/json", buf);
+             });
 
   _server.on("/api/scan", HTTP_POST, [this](AsyncWebServerRequest* request) {
     if (!request->authenticate("admin", "insomnia")) {

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -457,7 +457,7 @@ function wzShowPage(n) {
 function wzStartScan() {
     wzShowPage(2);
     document.getElementById('wz-tv-list').innerHTML = '';
-    document.getElementById('wz-scan-status').innerHTML = '<span class=”spinner”></span>Scanning network&hellip;';
+    document.getElementById('wz-scan-status').innerHTML = '<span class="spinner"></span>Scanning network&hellip;';
     fetch('/api/scan', {method:'POST'});
     wzPollCount = 0;
     wzPoll();
@@ -472,8 +472,8 @@ function wzPoll() {
         } else {
             document.getElementById('wz-scan-status').innerHTML = 'No smart TVs found.';
             document.getElementById('wz-tv-list').innerHTML =
-                '<p style=”color:#888;font-size:14px”>Make sure your TV is on and connected to the same network. ' +
-                '<a href=”#” onclick=”wzStartScan();return false”>Try again</a></p>';
+                '<p style="color:#888;font-size:14px">Make sure your TV is on and connected to the same network. ' +
+                '<a href="#" onclick="wzStartScan();return false">Try again</a></p>';
         }
     });
 }
@@ -486,10 +486,10 @@ function wzShowTvList(tvs) {
         const card = document.createElement('div');
         card.className = 'tv-card';
         card.innerHTML =
-            '<div class=”tv-icon”>&#128250;</div>' +
-            '<div style=”flex:1”><div class=”tv-name”>' + tv.name + '</div>' +
-            '<div class=”tv-meta”>' + (tv.model || 'Smart TV') + ' &nbsp;&middot;&nbsp; ' + tv.ip + '</div></div>' +
-            '<span style=”color:#bbb;font-size:20px”>&#8250;</span>';
+            '<div class="tv-icon">&#128250;</div>' +
+            '<div style="flex:1"><div class="tv-name">' + tv.name + '</div>' +
+            '<div class="tv-meta">' + (tv.model || 'Smart TV') + ' &nbsp;&middot;&nbsp; ' + tv.ip + '</div></div>' +
+            '<span style="color:#bbb;font-size:20px">&#8250;</span>';
         card.onclick = () => wzSelectTv(tv, card);
         list.appendChild(card);
     });
@@ -513,12 +513,12 @@ function wzBuildSensors(tv) {
         const row = document.createElement('div');
         row.className = 'wz-srow';
         row.innerHTML =
-            '<input type=”checkbox” id=”wsen' + i + '” ' + (s.enabled ? 'checked' : '') +
-            ' onchange=”wzSensors[' + i + '].enabled=this.checked”>' +
-            '<span class=”s-badge ' + s.type + '”>' + s.label + '</span>' +
-            '<div class=”wz-srow-info”>' +
-            '<div class=”wz-srow-name”>' + s.desc + '</div>' +
-            '<div class=”wz-srow-id”>' + s.id + '</div>' +
+            '<input type="checkbox" id="wsen' + i + '" ' + (s.enabled ? 'checked' : '') +
+            ' onchange="wzSensors[' + i + '].enabled=this.checked">' +
+            '<span class="s-badge ' + s.type + '">' + s.label + '</span>' +
+            '<div class="wz-srow-info">' +
+            '<div class="wz-srow-name">' + s.desc + '</div>' +
+            '<div class="wz-srow-id">' + s.id + '</div>' +
             '</div>';
         list.appendChild(row);
     });
@@ -544,7 +544,7 @@ async function wzCreate() {
         if (r.ok) created++;
     }
     document.getElementById('wz-done-title').textContent = created + ' sensor' + (created !== 1 ? 's' : '') + ' added!';
-    document.getElementById('wz-done-msg').textContent   = 'Sensors for “' + wzTv.name + '” are now active in the registry.';
+    document.getElementById('wz-done-msg').textContent   = 'Sensors for "' + wzTv.name + '" are now active in the registry.';
     wzShowPage(4);
 }
 

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -1,9 +1,7 @@
 // Copyright 2026 insomniaTV Contributors. All rights reserved.
 
 #include "WebServer.h"
-
 #include <ArduinoJson.h>
-
 #include <string>
 
 #if defined(ARDUINO)
@@ -19,8 +17,9 @@ namespace InsomniaTV {
 #if defined(ARDUINO)
 AsyncEventSource events("/events");
 
-WebServer::WebServer(uint16_t port, SamsungTvDiscovery& discovery)
-    : _server(port), _discovery(discovery) {
+WebServer::WebServer(uint16_t port, SamsungTvDiscovery& discovery,
+                     ConfigManager& configMgr)
+    : _server(port), _discovery(discovery), _configMgr(configMgr) {
   setupRoutes();
 }
 
@@ -123,6 +122,7 @@ void WebServer::setupRoutes() {
 
 <div id="Sensors" class="tabcontent">
   <h3>Sensor Registry</h3>
+  <button onclick="openModal()">Add Sensor</button>
   <table>
     <thead>
       <tr>
@@ -138,6 +138,26 @@ void WebServer::setupRoutes() {
   </table>
 </div>
 
+<div id="sensorModal" style="display:none; position:fixed; z-index:1; left:0; top:0; width:100%; height:100%; background-color:rgba(0,0,0,0.4);">
+  <div style="background-color:#fefefe; margin:15% auto; padding:20px; border:1px solid #888; width:50%;">
+    <span onclick="closeModal()" style="float:right; cursor:pointer;">&times;</span>
+    <h3>Add Sensor</h3>
+    <form id="sensorForm">
+      <label>ID:</label><input type="text" id="sensorId" required><br>
+      <label>Type:</label>
+      <select id="sensorType" onchange="updateFormFields()">
+        <option value="gpio_input">GPIO Input</option>
+        <option value="gpio_analog">GPIO Analog</option>
+        <option value="ping">Ping</option>
+        <option value="http">HTTP</option>
+        <option value="upnp">UPnP</option>
+      </select><br>
+      <div id="dynamicFields"></div>
+      <button type="button" onclick="saveSensor()">Save</button>
+    </form>
+  </div>
+</div>
+
 <script>
 const source = new EventSource('/events');
 source.addEventListener('sensor_update', function(e) {
@@ -148,6 +168,32 @@ source.addEventListener('sensor_update', function(e) {
         row.cells[3].textContent = data.available ? '🟢' : '🔴';
     }
 }, false);
+
+function openModal() { document.getElementById('sensorModal').style.display = 'block'; updateFormFields(); }
+function closeModal() { document.getElementById('sensorModal').style.display = 'none'; }
+
+function updateFormFields() {
+    const type = document.getElementById('sensorType').value;
+    const fields = document.getElementById('dynamicFields');
+    fields.innerHTML = '';
+    if (type === 'gpio_input') {
+        fields.innerHTML = '<label>Pin:</label><input type="number" id="s_pin"><label>Pullup:</label><input type="checkbox" id="s_pullup" checked>';
+    } else if (type === 'ping') {
+        fields.innerHTML = '<label>Target IP:</label><input type="text" id="s_target_ip">';
+    }
+}
+
+function saveSensor() {
+    const data = {
+        id: document.getElementById('sensorId').value,
+        type: document.getElementById('sensorType').value
+    };
+    fetch('/api/sensors', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(data)
+    }).then(() => { closeModal(); loadSensors(); });
+}
 
 function openTab(evt, tabName) {
     var i, tabcontent, tablinks;
@@ -185,8 +231,6 @@ function loadSensors() {
             tr.innerHTML = `<td>${s.id}</td><td>${s.type}</td><td>${s.value}</td><td>${s.available ? '🟢' : '🔴'}</td><td><button onclick="testSensor('${s.id}')">Test</button></td>`;
             tbody.appendChild(tr);
         });
-    }).catch(err => {
-        console.error('Error loading sensors:', err);
     });
 }
 
@@ -275,12 +319,35 @@ document.getElementsByClassName('tablinks')[0].click();
       obj["id"] = sensor->getId();
       obj["type"] = sensor->getType();
       obj["available"] = sensor->isAvailable();
-      // Use config to represent type-specific metadata if needed
       obj["value"] = sensor->read();
     }
     String response;
     serializeJson(doc, response);
     request->send(200, "application/json", response);
+  });
+
+  _server.on("/api/sensors", HTTP_POST, [](AsyncWebServerRequest* request) {
+    if (!request->authenticate("admin", "insomnia")) {
+      return request->requestAuthentication();
+    }
+  }, NULL, [this](AsyncWebServerRequest* request, uint8_t* data, size_t len,
+              size_t index, size_t total) {
+    JsonDocument doc;
+    deserializeJson(doc, data, len);
+
+    // Save to configuration
+    Config cfg = _configMgr.get();
+    JsonDocument sensorDoc;
+    deserializeJson(sensorDoc, cfg.sensorsJson);
+    sensorDoc.add(doc);
+    serializeJson(sensorDoc, cfg.sensorsJson);
+    _configMgr.set(cfg);
+    _configMgr.save();
+
+    // Register immediately
+    SensorManager::instance().init(cfg.sensorsJson, _discovery);
+
+    request->send(200, "application/json", "{\"status\":\"ok\"}");
   });
 
   _server.on(
@@ -365,8 +432,8 @@ document.getElementsByClassName('tablinks')[0].click();
              });
 }
 #else
-WebServer::WebServer(uint16_t port, SamsungTvDiscovery& discovery)
-    : _discovery(discovery) {}
+WebServer::WebServer(uint16_t port, SamsungTvDiscovery& discovery, ConfigManager& configMgr)
+    : _discovery(discovery), _configMgr(configMgr) {}
 void WebServer::begin() {}
 void WebServer::setupRoutes() {}
 #endif

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -96,7 +96,8 @@ void WebServer::setupRoutes() {
         .wz-dot.done { background:#81c784; color:#fff; }
         .wz-line { flex:1; height:2px; background:#ddd; max-width:48px; transition:.3s; }
         .wz-line.done { background:#81c784; }
-        .wz-footer { display:flex; gap:8px; justify-content:flex-end; margin-top:20px; padding-top:15px; border-top:1px solid #eee; }
+        .wz-footer { display:flex; gap:8px; justify-content:space-between; align-items:center; margin-top:20px; padding-top:15px; border-top:1px solid #eee; }
+        .wz-footer-right { display:flex; gap:8px; }
         .tv-card { border:2px solid #ddd; border-radius:8px; padding:12px 16px; margin:8px 0; cursor:pointer; display:flex; align-items:center; gap:14px; transition:.15s; }
         .tv-card:hover { border-color:#90caf9; background:#e3f2fd; }
         .tv-card.selected { border-color:#4CAF50; background:#e8f5e9; }
@@ -233,11 +234,14 @@ void WebServer::setupRoutes() {
     </div>
 
     <div class="wz-footer">
-      <button id="wbtn-cancel" class="btn-gray"  onclick="closeWizard()">Cancel</button>
-      <button id="wbtn-back"   class="btn-gray"  style="display:none" onclick="wzBack()">&#8592; Back</button>
-      <button id="wbtn-scan"   class="btn-tv"    onclick="wzStartScan()">Start Scan</button>
-      <button id="wbtn-add"    class="btn-tv"    style="display:none" onclick="wzCreate()">Add to Sensors &#8594;</button>
-      <button id="wbtn-done"   style="display:none" onclick="closeWizard();loadSensors()">Done</button>
+      <button id="wbtn-cancel" class="btn-gray" onclick="closeWizard()">Cancel</button>
+      <div class="wz-footer-right">
+        <button id="wbtn-back"   class="btn-gray" style="display:none" onclick="wzBack()">&#8592; Back</button>
+        <button id="wbtn-rescan" class="btn-tv"   style="display:none" onclick="wzStartScan()">&#8635; Rescan</button>
+        <button id="wbtn-scan"   class="btn-tv"   onclick="wzStartScan()">Start Scan</button>
+        <button id="wbtn-add"    class="btn-tv"   style="display:none" onclick="wzCreate()">Add to Sensors &#8594;</button>
+        <button id="wbtn-done"   style="display:none" onclick="closeWizard();loadSensors()">Done</button>
+      </div>
     </div>
   </div>
 </div>
@@ -449,6 +453,7 @@ function wzShowPage(n) {
     });
     document.getElementById('wbtn-cancel').style.display = n < 4 ? '' : 'none';
     document.getElementById('wbtn-back').style.display   = n === 3 ? '' : 'none';
+    document.getElementById('wbtn-rescan').style.display = n === 2 ? '' : 'none';
     document.getElementById('wbtn-scan').style.display   = n === 1 ? '' : 'none';
     document.getElementById('wbtn-add').style.display    = n === 3 ? '' : 'none';
     document.getElementById('wbtn-done').style.display   = n === 4 ? '' : 'none';

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -61,17 +61,28 @@ void WebServer::setupRoutes() {
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>insomniaTV</title>
     <style>
-        body { font-family: sans-serif; margin: 0; padding: 0; }
-        .tab { overflow: hidden; background-color: #f1f1f1; }
-        .tab button { background-color: inherit; border: none; outline: none; cursor: pointer; padding: 14px 16px; transition: 0.3s; }
-        .tab button:hover { background-color: #ddd; }
-        .tab button.active { background-color: #ccc; }
-        .tabcontent { display: none; padding: 12px; border: 1px solid #ccc; border-top: none; }
-        fieldset { margin-bottom: 15px; border: 1px solid #ccc; padding: 10px; }
-        legend { font-weight: bold; }
-        table { width: 100%; border-collapse: collapse; }
-        th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
-        tr:nth-child(even) { background-color: #f2f2f2; }
+        body { font-family: sans-serif; margin: 0; padding: 0; background: #f4f4f9; color: #333; }
+        .tab { overflow: hidden; background-color: #333; }
+        .tab button { background-color: inherit; border: none; outline: none; cursor: pointer; padding: 14px 16px; transition: 0.3s; color: white; }
+        .tab button:hover { background-color: #555; }
+        .tab button.active { background-color: #4CAF50; }
+        .tabcontent { display: none; padding: 20px; }
+        fieldset { margin-bottom: 15px; border: 1px solid #ccc; padding: 15px; background: white; border-radius: 5px; }
+        legend { font-weight: bold; padding: 0 5px; }
+        table { width: 100%; border-collapse: collapse; background: white; border-radius: 5px; overflow: hidden; }
+        th, td { border: 1px solid #ddd; padding: 12px; text-align: left; }
+        tr:nth-child(even) { background-color: #f9f9f9; }
+        button { cursor: pointer; padding: 8px 12px; border: none; border-radius: 4px; background: #4CAF50; color: white; }
+        button:hover { background: #45a049; }
+        button.delete { background: #f44336; }
+        button.delete:hover { background: #da190b; }
+        .modal { display:none; position:fixed; z-index:100; left:0; top:0; width:100%; height:100%; background-color:rgba(0,0,0,0.5); }
+        .modal-content { background-color:#fefefe; margin:10% auto; padding:25px; border:1px solid #888; width:80%; max-width: 500px; border-radius: 8px; }
+        .close { float:right; cursor:pointer; font-size: 24px; }
+        label { display: block; margin: 10px 0 5px; font-weight: bold; }
+        input[type=text], input[type=number], select { width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box; }
+        .discovery-item { padding: 8px; border-bottom: 1px solid #eee; cursor: pointer; }
+        .discovery-item:hover { background: #f0f0f0; }
     </style>
 </head>
 <body>
@@ -91,28 +102,12 @@ void WebServer::setupRoutes() {
     <p><b>Chip ID:</b> <span id="sys-chipId"></span></p>
     <p><b>Free Heap:</b> <span id="sys-freeHeap"></span></p>
   </fieldset>
-  <fieldset>
-    <legend>Network</legend>
-    <p><b>IP Address:</b> <span id="sys-ip"></span></p>
-    <p><b>MAC:</b> <span id="sys-mac"></span></p>
-    <p><b>DHCP:</b> <span id="sys-dhcp"></span></p>
-    <p><b>AP Name:</b> <span id="sys-ap"></span></p>
-  </fieldset>
-  <fieldset>
-    <legend>WiFi</legend>
-    <p><b>Status:</b> <span id="sys-wifiStatus"></span></p>
-    <p><b>SSID:</b> <span id="sys-ssid"></span></p>
-    <p><b>RSSI:</b> <span id="sys-rssi"></span> dBm</p>
-  </fieldset>
 </div>
 
 <div id="Config" class="tabcontent">
-  <h3>WiFi & TV Config</h3>
-  <button onclick="scanTV()">Scan for TVs</button>
-  <div id="discovery-content">
-      <h4>Discovered TVs:</h4>
-      <ul id="tv-list"></ul>
-  </div>
+  <h3>TV Discovery</h3>
+  <button onclick="scanTV()">Scan Network</button>
+  <ul id="tv-list"></ul>
   <h3>Firmware Update</h3>
   <form method="POST" action="/update" enctype="multipart/form-data">
     <input type="file" name="update">
@@ -122,7 +117,7 @@ void WebServer::setupRoutes() {
 
 <div id="Sensors" class="tabcontent">
   <h3>Sensor Registry</h3>
-  <button onclick="openModal()">Add Sensor</button>
+  <button onclick="openModal()" style="margin-bottom: 15px;">Add New Sensor</button>
   <table>
     <thead>
       <tr>
@@ -138,22 +133,26 @@ void WebServer::setupRoutes() {
   </table>
 </div>
 
-<div id="sensorModal" style="display:none; position:fixed; z-index:1; left:0; top:0; width:100%; height:100%; background-color:rgba(0,0,0,0.4);">
-  <div style="background-color:#fefefe; margin:15% auto; padding:20px; border:1px solid #888; width:50%;">
-    <span onclick="closeModal()" style="float:right; cursor:pointer;">&times;</span>
+<div id="sensorModal" class="modal">
+  <div class="modal-content">
+    <span onclick="closeModal()" class="close">&times;</span>
     <h3>Add Sensor</h3>
     <form id="sensorForm">
-      <label>ID:</label><input type="text" id="sensorId" required><br>
-      <label>Type:</label>
+      <label>Unique ID:</label>
+      <input type="text" id="sensorId" placeholder="e.g., room_motion" required>
+
+      <label>Sensor Type:</label>
       <select id="sensorType" onchange="updateFormFields()">
-        <option value="gpio_input">GPIO Input</option>
-        <option value="gpio_analog">GPIO Analog</option>
-        <option value="ping">Ping</option>
-        <option value="http">HTTP</option>
-        <option value="upnp">UPnP</option>
-      </select><br>
+        <option value="gpio_input">GPIO Input (Digital)</option>
+        <option value="gpio_analog">GPIO Analog (ADC)</option>
+        <option value="ping">Ping (ICMP)</option>
+        <option value="http">HTTP (GET)</option>
+        <option value="upnp">UPnP (Discovery)</option>
+      </select>
+
       <div id="dynamicFields"></div>
-      <button type="button" onclick="saveSensor()">Save</button>
+
+      <button type="button" onclick="saveSensor()" style="margin-top: 20px; width: 100%;">Save Sensor</button>
     </form>
   </div>
 </div>
@@ -169,32 +168,6 @@ source.addEventListener('sensor_update', function(e) {
     }
 }, false);
 
-function openModal() { document.getElementById('sensorModal').style.display = 'block'; updateFormFields(); }
-function closeModal() { document.getElementById('sensorModal').style.display = 'none'; }
-
-function updateFormFields() {
-    const type = document.getElementById('sensorType').value;
-    const fields = document.getElementById('dynamicFields');
-    fields.innerHTML = '';
-    if (type === 'gpio_input') {
-        fields.innerHTML = '<label>Pin:</label><input type="number" id="s_pin"><label>Pullup:</label><input type="checkbox" id="s_pullup" checked>';
-    } else if (type === 'ping') {
-        fields.innerHTML = '<label>Target IP:</label><input type="text" id="s_target_ip">';
-    }
-}
-
-function saveSensor() {
-    const data = {
-        id: document.getElementById('sensorId').value,
-        type: document.getElementById('sensorType').value
-    };
-    fetch('/api/sensors', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(data)
-    }).then(() => { closeModal(); loadSensors(); });
-}
-
 function openTab(evt, tabName) {
     var i, tabcontent, tablinks;
     tabcontent = document.getElementsByClassName("tabcontent");
@@ -202,23 +175,20 @@ function openTab(evt, tabName) {
     tablinks = document.getElementsByClassName("tablinks");
     for (i = 0; i < tablinks.length; i++) { tablinks[i].className = tablinks[i].className.replace(" active", ""); }
 
-    if (tabName === 'Status') {
-        fetch('/api/status').then(r => r.json()).then(data => {
-            for (const [key, value] of Object.entries(data)) {
-                const el = document.getElementById('sys-' + key);
-                if (el) el.textContent = value;
-            }
-        }).catch(err => {
-            document.getElementById('sys-status').textContent = 'Error: ' + err;
-        });
-    } else if (tabName === 'Config') {
-        loadDiscovery();
-    } else if (tabName === 'Sensors') {
-        loadSensors();
-    }
-
     document.getElementById(tabName).style.display = "block";
     evt.currentTarget.className += " active";
+
+    if (tabName === 'Status') loadStatus();
+    if (tabName === 'Sensors') loadSensors();
+}
+
+function loadStatus() {
+    fetch('/api/status').then(r => r.json()).then(data => {
+        for (const [key, value] of Object.entries(data)) {
+            const el = document.getElementById('sys-' + key);
+            if (el) el.textContent = value;
+        }
+    });
 }
 
 function loadSensors() {
@@ -228,10 +198,105 @@ function loadSensors() {
         data.forEach(s => {
             const tr = document.createElement('tr');
             tr.id = 'sensor-row-' + s.id;
-            tr.innerHTML = `<td>${s.id}</td><td>${s.type}</td><td>${s.value}</td><td>${s.available ? '🟢' : '🔴'}</td><td><button onclick="testSensor('${s.id}')">Test</button></td>`;
+            tr.innerHTML = `
+                <td>${s.id}</td>
+                <td>${s.type}</td>
+                <td>${s.value}</td>
+                <td>${s.available ? '🟢' : '🔴'}</td>
+                <td>
+                    <button onclick="testSensor('${s.id}')">Test</button>
+                    <button class="delete" onclick="deleteSensor('${s.id}')">Delete</button>
+                </td>`;
             tbody.appendChild(tr);
         });
     });
+}
+
+function openModal() { document.getElementById('sensorModal').style.display = 'block'; updateFormFields(); }
+function closeModal() { document.getElementById('sensorModal').style.display = 'none'; }
+
+function updateFormFields() {
+    const type = document.getElementById('sensorType').value;
+    const fields = document.getElementById('dynamicFields');
+    fields.innerHTML = '';
+
+    if (type === 'gpio_input') {
+        fields.innerHTML = `
+            <label>Pin Number:</label><input type="number" id="s_pin" value="0">
+            <label>Pullup:</label><input type="checkbox" id="s_pullup" checked>
+            <label>Debounce (ms):</label><input type="number" id="s_debounce" value="50">`;
+    } else if (type === 'gpio_analog') {
+        fields.innerHTML = `
+            <label>Pin Number:</label><input type="number" id="s_pin" value="0">
+            <label>Scale:</label><input type="number" id="s_scale" step="0.001" value="1.0">
+            <label>Offset:</label><input type="number" id="s_offset" step="0.001" value="0.0">`;
+    } else if (type === 'ping') {
+        fields.innerHTML = `<label>Target IP/Host:</label><input type="text" id="s_target" placeholder="192.168.1.1">`;
+    } else if (type === 'http') {
+        fields.innerHTML = `<label>URL:</label><input type="text" id="s_url" placeholder="http://api.local/status">`;
+    } else if (type === 'upnp') {
+        fields.innerHTML = `
+            <label>Select Device:</label>
+            <div id="upnp-list" style="border: 1px solid #ccc; max-height: 100px; overflow-y: auto;">Scanning...</div>
+            <input type="hidden" id="s_target_name">`;
+        fetchUpnpDevices();
+    }
+}
+
+function fetchUpnpDevices() {
+    fetch('/api/discovery').then(r => r.json()).then(data => {
+        const list = document.getElementById('upnp-list');
+        list.innerHTML = '';
+        if (data.length === 0) list.innerHTML = '<div class="discovery-item">No TVs found. Scan in Config tab first.</div>';
+        data.forEach(tv => {
+            const div = document.createElement('div');
+            div.className = 'discovery-item';
+            div.textContent = `${tv.name} (${tv.ip})`;
+            div.onclick = () => {
+                document.getElementById('s_target_name').value = tv.name;
+                Array.from(list.children).forEach(c => c.style.background = '');
+                div.style.background = '#e0e0e0';
+            };
+            list.appendChild(div);
+        });
+    });
+}
+
+function saveSensor() {
+    const id = document.getElementById('sensorId').value;
+    const type = document.getElementById('sensorType').value;
+    if (!id) return alert('ID is required');
+
+    const config = { id, type };
+    if (type === 'gpio_input') {
+        config.pin = parseInt(document.getElementById('s_pin').value);
+        config.pullup = document.getElementById('s_pullup').checked;
+        config.debounce_ms = parseInt(document.getElementById('s_debounce').value);
+    } else if (type === 'gpio_analog') {
+        config.pin = parseInt(document.getElementById('s_pin').value);
+        config.scale = parseFloat(document.getElementById('s_scale').value);
+        config.offset = parseFloat(document.getElementById('s_offset').value);
+    } else if (type === 'ping') {
+        config.target_ip = document.getElementById('s_target').value;
+    } else if (type === 'http') {
+        config.url = document.getElementById('s_url').value;
+    } else if (type === 'upnp') {
+        config.target_name = document.getElementById('s_target_name').value;
+    }
+
+    fetch('/api/sensors', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(config)
+    }).then(r => {
+        if (r.ok) { closeModal(); loadSensors(); }
+        else alert('Failed to save');
+    });
+}
+
+function deleteSensor(id) {
+    if (!confirm('Delete sensor ' + id + '?')) return;
+    fetch('/api/sensors?id=' + id, { method: 'DELETE' }).then(() => loadSensors());
 }
 
 function testSensor(id) {
@@ -240,40 +305,27 @@ function testSensor(id) {
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
         body: 'id=' + id
     }).then(r => r.json()).then(data => {
-        alert('Test result for ' + data.id + ': ' + data.value);
-    }).catch(err => {
-        alert('Test failed: ' + err);
+        alert('Test result for ' + data.id + ': ' + (data.value ? 'HIGH/OK' : 'LOW/FAIL'));
     });
 }
 
 function scanTV() {
-    document.getElementById('tv-list').textContent = 'Scanning...';
-    fetch('/api/scan', {method: 'POST'}).then(r => r.json()).then(data => {
-        setTimeout(loadDiscovery, 3000);
-    }).catch(err => {
-        document.getElementById('tv-list').textContent = 'Error: ' + err;
-    });
+    document.getElementById('tv-list').innerHTML = '<li>Scanning...</li>';
+    fetch('/api/scan', {method: 'POST'}).then(() => setTimeout(loadDiscovery, 3000));
 }
 function loadDiscovery() {
-    fetch('/api/discovery').then(r => r.json()).then(renderDiscovery).catch(err => {
-        document.getElementById('tv-list').textContent = 'Error: ' + err;
+    fetch('/api/discovery').then(r => r.json()).then(data => {
+        let list = document.getElementById('tv-list');
+        list.innerHTML = '';
+        data.forEach(tv => {
+            let li = document.createElement('li');
+            li.innerHTML = `<b>${tv.name}</b> (${tv.ip}) - ${tv.model}`;
+            list.appendChild(li);
+        });
     });
 }
-function renderDiscovery(data) {
-    let list = document.getElementById('tv-list');
-    list.innerHTML = '';
-    data.forEach(tv => {
-        let li = document.createElement('li');
-        li.innerHTML = `<b>Name:</b> ${tv.name} | <b>Model:</b> ${tv.model} | <b>IP:</b> ${tv.ip}`;
-        list.appendChild(li);
-    });
-}
-// Default open Status tab
+
 document.getElementsByClassName('tablinks')[0].click();
-// Trigger sensors load if it's the active tab
-if (document.getElementsByClassName('tablinks')[2].classList.contains('active')) {
-    loadSensors();
-}
 </script>
 
 </body>
@@ -343,15 +395,59 @@ if (document.getElementsByClassName('tablinks')[2].classList.contains('active'))
     Config cfg = _configMgr.get();
     JsonDocument sensorDoc;
     deserializeJson(sensorDoc, cfg.sensorsJson);
-    sensorDoc.add(doc);
+
+    // Check if it already exists to avoid duplicates
+    bool found = false;
+    for (JsonObject s : sensorDoc.as<JsonArray>()) {
+        if (s["id"] == doc["id"]) {
+            s.set(doc.as<JsonObject>());
+            found = true;
+            break;
+        }
+    }
+    if (!found) sensorDoc.add(doc);
+
     serializeJson(sensorDoc, cfg.sensorsJson);
     _configMgr.set(cfg);
     _configMgr.save();
 
-    // Register immediately
+    // Re-register immediately
     SensorManager::instance().init(cfg.sensorsJson, _discovery);
 
     request->send(200, "application/json", "{\"status\":\"ok\"}");
+  });
+
+  _server.on("/api/sensors", HTTP_DELETE, [this](AsyncWebServerRequest* request) {
+    if (!request->authenticate("admin", "insomnia")) {
+      return request->requestAuthentication();
+    }
+    if (request->hasParam("id")) {
+      String id = request->getParam("id")->value();
+
+      // Remove from configuration
+      Config cfg = _configMgr.get();
+      JsonDocument sensorDoc;
+      deserializeJson(sensorDoc, cfg.sensorsJson);
+
+      JsonArray array = sensorDoc.as<JsonArray>();
+      for (size_t i = 0; i < array.size(); i++) {
+          if (array[i]["id"] == id) {
+              array.remove(i);
+              break;
+          }
+      }
+
+      serializeJson(sensorDoc, cfg.sensorsJson);
+      _configMgr.set(cfg);
+      _configMgr.save();
+
+      // For now, simple re-init (might need a clear() in SensorManager if instances linger)
+      SensorManager::instance().init(cfg.sensorsJson, _discovery);
+
+      request->send(200, "application/json", "{\"status\":\"ok\"}");
+      return;
+    }
+    request->send(400);
   });
 
   _server.on(
@@ -436,7 +532,8 @@ if (document.getElementsByClassName('tablinks')[2].classList.contains('active'))
              });
 }
 #else
-WebServer::WebServer(uint16_t port, SamsungTvDiscovery& discovery, ConfigManager& configMgr)
+WebServer::WebServer(uint16_t port, SamsungTvDiscovery& discovery,
+                     ConfigManager& configMgr)
     : _discovery(discovery), _configMgr(configMgr) {}
 void WebServer::begin() {}
 void WebServer::setupRoutes() {}

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -103,15 +103,14 @@ void WebServer::setupRoutes() {
         .tv-icon { font-size:32px; line-height:1; }
         .tv-name { font-weight:bold; font-size:15px; }
         .tv-meta { color:#777; font-size:13px; margin-top:2px; }
-        .sensor-preview-row { display:flex; align-items:center; gap:8px; padding:9px 10px; border:1px solid #e8e8e8; border-radius:6px; margin:6px 0; background:#fafafa; }
-        .sensor-preview-row input[type=checkbox] { width:auto; margin:0; flex-shrink:0; }
-        .s-badge { font-size:11px; padding:2px 7px; border-radius:10px; background:#e0e0e0; color:#555; white-space:nowrap; }
+        .s-badge { font-size:11px; padding:2px 7px; border-radius:10px; background:#e0e0e0; color:#555; white-space:nowrap; flex-shrink:0; }
         .s-badge.ping { background:#e3f2fd; color:#1565c0; }
         .s-badge.upnp { background:#f3e5f5; color:#6a1b9a; }
         .s-badge.http { background:#e8f5e9; color:#2e7d32; }
-        .s-id-wrap { flex:1; min-width:0; }
-        .s-id-wrap input { padding:4px 6px; font-size:13px; border:1px solid #ccc; border-radius:4px; width:100%; box-sizing:border-box; }
-        .s-desc { color:#999; font-size:11px; margin-top:3px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+        .wz-srow { display:flex; align-items:center; gap:10px; padding:8px 12px; border:1px solid #ddd; border-radius:6px; margin:5px 0; background:#fafafa; }
+        .wz-srow input[type=checkbox] { width:auto; flex-shrink:0; margin:0; }
+        .wz-srow .wz-sid { flex:1; min-width:0; width:auto; box-sizing:border-box; padding:5px 8px; font-size:13px; border:1px solid #ccc; border-radius:4px; }
+        .wz-sdesc { color:#888; font-size:12px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; flex-shrink:1; max-width:180px; }
         .spinner { display:inline-block; width:18px; height:18px; border:3px solid #ddd; border-top-color:#4CAF50; border-radius:50%; animation:spin .7s linear infinite; vertical-align:middle; margin-right:8px; }
         @keyframes spin { to { transform:rotate(360deg); } }
         .btn-tv { background:#1565c0; }
@@ -511,14 +510,13 @@ function wzBuildSensors(tv) {
     list.innerHTML = '';
     wzSensors.forEach((s, i) => {
         const row = document.createElement('div');
-        row.className = 'sensor-preview-row';
+        row.className = 'wz-srow';
         row.innerHTML =
             '<input type=”checkbox” id=”wsen' + i + '” ' + (s.enabled ? 'checked' : '') +
             ' onchange=”wzSensors[' + i + '].enabled=this.checked”>' +
             '<span class=”s-badge ' + s.type + '”>' + s.label + '</span>' +
-            '<div class=”s-id-wrap”>' +
-            '<input type=”text” value=”' + s.id + '” oninput=”wzSensors[' + i + '].id=this.value”>' +
-            '<div class=”s-desc”>' + s.desc + '</div></div>';
+            '<input type=”text” class=”wz-sid” value=”' + s.id + '” oninput=”wzSensors[' + i + '].id=this.value”>' +
+            '<span class=”wz-sdesc”>' + s.desc + '</span>';
         list.appendChild(row);
     });
 }

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -3,21 +3,50 @@
 #include "WebServer.h"
 
 #include <ArduinoJson.h>
+
+#include <string>
+
 #if defined(ARDUINO)
+#include <AsyncEventSource.h>
+#include <Update.h>
 #include <WiFi.h>
 #endif
-#include <string>
+
+#include "../sensors/SensorManager.h"
 
 namespace InsomniaTV {
 
 #if defined(ARDUINO)
+AsyncEventSource events("/events");
+
 WebServer::WebServer(uint16_t port, SamsungTvDiscovery& discovery)
     : _server(port), _discovery(discovery) {
   setupRoutes();
 }
 
 void WebServer::begin() {
+  _server.addHandler(&events);
   _server.begin();
+
+  // Periodic sensor reader task
+  xTaskCreate(
+      [](void* pvParameters) {
+        for (;;) {
+          auto sensors = SensorManager::instance().listSensors();
+          for (auto const& s : sensors) {
+            bool val = s->read();
+            JsonDocument doc;
+            doc["id"] = s->getId();
+            doc["value"] = val;
+            doc["available"] = s->isAvailable();
+            String buf;
+            serializeJson(doc, buf);
+            events.send(buf.c_str(), "sensor_update", millis());
+          }
+          vTaskDelay(pdMS_TO_TICKS(5000));
+        }
+      },
+      "sensor_poll", 4096, NULL, 1, NULL);
 }
 
 void WebServer::setupRoutes() {
@@ -38,7 +67,12 @@ void WebServer::setupRoutes() {
         .tab button { background-color: inherit; border: none; outline: none; cursor: pointer; padding: 14px 16px; transition: 0.3s; }
         .tab button:hover { background-color: #ddd; }
         .tab button.active { background-color: #ccc; }
-        .tabcontent { display: none; padding: 6px 12px; border: 1px solid #ccc; border-top: none; }
+        .tabcontent { display: none; padding: 12px; border: 1px solid #ccc; border-top: none; }
+        fieldset { margin-bottom: 15px; border: 1px solid #ccc; padding: 10px; }
+        legend { font-weight: bold; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+        tr:nth-child(even) { background-color: #f2f2f2; }
     </style>
 </head>
 <body>
@@ -46,23 +80,31 @@ void WebServer::setupRoutes() {
 <div class="tab">
   <button class="tablinks" onclick="openTab(event, 'Status')">Status</button>
   <button class="tablinks" onclick="openTab(event, 'Config')">Config</button>
+  <button class="tablinks" onclick="openTab(event, 'Sensors')">Sensors</button>
 </div>
 
 <div id="Status" class="tabcontent">
   <h3>System Status</h3>
-  <div id="status-content">
+  <fieldset>
+    <legend>System</legend>
     <p><b>Status:</b> <span id="sys-status">Loading...</span></p>
     <p><b>Version:</b> <span id="sys-version"></span></p>
-    <p><b>MAC:</b> <span id="sys-mac"></span></p>
-    <p><b>SSID:</b> <span id="sys-ssid"></span></p>
-    <p><b>RSSI:</b> <span id="sys-rssi"></span> dBm</p>
+    <p><b>Chip ID:</b> <span id="sys-chipId"></span></p>
+    <p><b>Free Heap:</b> <span id="sys-freeHeap"></span></p>
+  </fieldset>
+  <fieldset>
+    <legend>Network</legend>
     <p><b>IP Address:</b> <span id="sys-ip"></span></p>
+    <p><b>MAC:</b> <span id="sys-mac"></span></p>
     <p><b>DHCP:</b> <span id="sys-dhcp"></span></p>
     <p><b>AP Name:</b> <span id="sys-ap"></span></p>
-    <p><b>Chip ID:</b> <span id="sys-chipid"></span></p>
-    <p><b>Free Heap:</b> <span id="sys-heap"></span></p>
-    <p><b>WiFi Status:</b> <span id="sys-wifi"></span></p>
-  </div>
+  </fieldset>
+  <fieldset>
+    <legend>WiFi</legend>
+    <p><b>Status:</b> <span id="sys-wifiStatus"></span></p>
+    <p><b>SSID:</b> <span id="sys-ssid"></span></p>
+    <p><b>RSSI:</b> <span id="sys-rssi"></span> dBm</p>
+  </fieldset>
 </div>
 
 <div id="Config" class="tabcontent">
@@ -72,9 +114,40 @@ void WebServer::setupRoutes() {
       <h4>Discovered TVs:</h4>
       <ul id="tv-list"></ul>
   </div>
+  <h3>Firmware Update</h3>
+  <form method="POST" action="/update" enctype="multipart/form-data">
+    <input type="file" name="update">
+    <input type="submit" value="Update">
+  </form>
+</div>
+
+<div id="Sensors" class="tabcontent">
+  <h3>Sensor Registry</h3>
+  <table>
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Type</th>
+        <th>Value</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody id="sensor-table-body">
+    </tbody>
+  </table>
 </div>
 
 <script>
+const source = new EventSource('/events');
+source.addEventListener('sensor_update', function(e) {
+    const data = JSON.parse(e.data);
+    const row = document.getElementById('sensor-row-' + data.id);
+    if (row) {
+        row.cells[2].textContent = data.value;
+        row.cells[3].textContent = data.available ? '🟢' : '🔴';
+    }
+}, false);
+
 function openTab(evt, tabName) {
     var i, tabcontent, tablinks;
     tabcontent = document.getElementsByClassName("tabcontent");
@@ -93,14 +166,30 @@ function openTab(evt, tabName) {
         });
     } else if (tabName === 'Config') {
         loadDiscovery();
+    } else if (tabName === 'Sensors') {
+        loadSensors();
     }
 
     document.getElementById(tabName).style.display = "block";
     evt.currentTarget.className += " active";
 }
+
+function loadSensors() {
+    fetch('/api/sensors').then(r => r.json()).then(data => {
+        const tbody = document.getElementById('sensor-table-body');
+        tbody.innerHTML = '';
+        data.forEach(s => {
+            const tr = document.createElement('tr');
+            tr.id = 'sensor-row-' + s.id;
+            tr.innerHTML = `<td>${s.id}</td><td>${s.type}</td><td>${s.value}</td><td>${s.available ? '🟢' : '🔴'}</td>`;
+            tbody.appendChild(tr);
+        });
+    });
+}
+
 function scanTV() {
     document.getElementById('tv-list').textContent = 'Scanning...';
-    fetch('/api/scan').then(r => r.json()).then(data => {
+    fetch('/api/scan', {method: 'POST'}).then(r => r.json()).then(data => {
         setTimeout(loadDiscovery, 3000);
     }).catch(err => {
         document.getElementById('tv-list').textContent = 'Error: ' + err;
@@ -159,12 +248,57 @@ document.getElementsByClassName('tablinks')[0].click();
     request->send(res);
   });
 
-  _server.on("/api/scan", HTTP_GET, [this](AsyncWebServerRequest* request) {
+  _server.on("/api/sensors", HTTP_GET, [](AsyncWebServerRequest* request) {
     if (!request->authenticate("admin", "insomnia")) {
       return request->requestAuthentication();
     }
+    auto sensors = SensorManager::instance().listSensors();
+    JsonDocument doc;
+    JsonArray array = doc.to<JsonArray>();
+    for (auto const& sensor : sensors) {
+      JsonObject obj = array.add<JsonObject>();
+      obj["id"] = sensor->getId();
+      obj["type"] = sensor->getType();
+      obj["available"] = sensor->isAvailable();
+      obj["value"] = sensor->read();
+    }
+    String response;
+    serializeJson(doc, response);
+    request->send(200, "application/json", response);
+  });
 
-    // Run scan in a separate task
+  _server.on(
+      "/update", HTTP_POST,
+      [](AsyncWebServerRequest* request) {
+        bool shouldReboot = !Update.hasError();
+        AsyncWebServerResponse* res = request->beginResponse(
+            200, "text/plain", shouldReboot ? "OK" : "FAIL");
+        res->addHeader("Connection", "close");
+        request->send(res);
+        if (shouldReboot)
+          ESP.restart();
+      },
+      [](AsyncWebServerRequest* request, String filename, size_t index,
+         uint8_t* data, size_t len, bool final) {
+        if (!index) {
+          if (!Update.begin(UPDATE_SIZE_UNKNOWN)) {
+            Update.printError(Serial);
+          }
+        }
+        if (Update.write(data, len) != len) {
+          Update.printError(Serial);
+        }
+        if (final) {
+          if (!Update.end(true)) {
+            Update.printError(Serial);
+          }
+        }
+      });
+
+  _server.on("/api/scan", HTTP_POST, [this](AsyncWebServerRequest* request) {
+    if (!request->authenticate("admin", "insomnia")) {
+      return request->requestAuthentication();
+    }
     xTaskCreate(
         [](void* pvParameters) {
           auto* self = static_cast<WebServer*>(pvParameters);
@@ -194,33 +328,6 @@ document.getElementsByClassName('tablinks')[0].click();
                serializeJson(doc, response);
                request->send(200, "application/json", response);
              });
-
-  _server.on("/discovery", HTTP_GET, [this](AsyncWebServerRequest* request) {
-    if (!request->authenticate("admin", "insomnia")) {
-      return request->requestAuthentication();
-    }
-    std::string html = "<h1>Samsung TV Discovery</h1>";
-    if (_discovery.isScanning()) {
-      html += "<p>Scan in progress... <a href='/discovery'>Refresh</a></p>";
-    } else {
-      html += "<ul>";
-      for (const auto& tv : _discovery.getDiscoveredTvs()) {
-        html += "<li><b>Name:</b> " + tv.name + " | <b>Model:</b> " + tv.model +
-                " | <b>IP:</b> " + tv.ip + "</li>";
-      }
-      html += "</ul><p><a href='/api/scan'>Start New Scan</a></p>";
-    }
-    request->send(200, "text/html", html.c_str());
-  });
-
-  _server.on("/wifi", HTTP_GET, [](AsyncWebServerRequest* request) {
-    if (!request->authenticate("admin", "insomnia")) {
-      return request->requestAuthentication();
-    }
-    request->send(200, "text/html",
-                  "<h1>WiFi Configuration</h1><p>Placeholder for WiFi "
-                  "setup. Use physical button (10s) to reset.</p>");
-  });
 }
 #else
 WebServer::WebServer(uint16_t port, SamsungTvDiscovery& discovery)

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -104,17 +104,16 @@ void WebServer::setupRoutes() {
         .tv-icon { font-size:32px; line-height:1; }
         .tv-name { font-weight:bold; font-size:15px; }
         .tv-meta { color:#777; font-size:13px; margin-top:2px; }
-        .sensor-preview-row { display:flex; align-items:flex-start; gap:10px; padding:12px; border:1px solid #e8e8e8; border-radius:6px; margin:6px 0; background:#fafafa; }
-        .sensor-preview-row input[type=checkbox] { width:auto; margin:3px 0 0; flex-shrink:0; }
-        .s-preview-body { flex:1; min-width:0; }
-        .s-preview-header { display:flex; justify-content:space-between; align-items:center; margin-bottom:6px; }
-        .s-probe { font-size:13px; color:#555; white-space:nowrap; }
-        .s-badge { font-size:11px; padding:2px 8px; border-radius:10px; background:#e0e0e0; color:#555; white-space:nowrap; font-weight:600; }
+        .s3-sensor { margin:5px 0 8px; }
+        .s3-row { display:flex; align-items:center; gap:8px; padding:8px 12px; background:#fafafa; border:1px solid #ddd; border-radius:6px 6px 0 0; }
+        .s3-check { flex-shrink:0; width:15px !important; height:15px; margin:0; cursor:pointer; accent-color:#4CAF50; }
+        .s-badge { font-size:11px; padding:2px 8px; border-radius:10px; background:#e0e0e0; color:#555; white-space:nowrap; font-weight:600; flex-shrink:0; }
         .s-badge.ping { background:#e3f2fd; color:#1565c0; }
         .s-badge.upnp { background:#f3e5f5; color:#6a1b9a; }
         .s-badge.http { background:#e8f5e9; color:#2e7d32; }
-        .s-preview-body input[type=text] { width:100%; padding:5px 7px; font-size:13px; border:1px solid #ccc; border-radius:4px; box-sizing:border-box; }
-        .s-desc { color:#999; font-size:11px; margin-top:4px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+        .s3-id { flex:1 1 0 !important; width:0 !important; min-width:0; padding:4px 7px !important; font-size:13px; border:1px solid #ddd; border-radius:4px; box-sizing:border-box; }
+        .s3-status { flex-shrink:0; width:72px; text-align:right; font-size:13px; color:#444; white-space:nowrap; }
+        .s3-desc { font-size:11px; color:#888; padding:3px 12px 5px; background:#fafafa; border:1px solid #ddd; border-top:none; border-radius:0 0 6px 6px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
         .spinner { display:inline-block; width:14px; height:14px; border:2px solid #ddd; border-top-color:#4CAF50; border-radius:50%; animation:spin .7s linear infinite; vertical-align:middle; }
         @keyframes spin { to { transform:rotate(360deg); } }
         .btn-tv { background:#1565c0; }
@@ -524,20 +523,18 @@ function wzBuildSensors(tv) {
     const list = document.getElementById('wz-sensor-list');
     list.innerHTML = '';
     wzSensors.forEach((s, i) => {
-        const row = document.createElement('div');
-        row.className = 'sensor-preview-row';
-        row.innerHTML =
-            '<input type=”checkbox” id=”wsen'+i+'” '+(s.enabled?'checked':'')+
-            ' onchange=”wzSensors['+i+'].enabled=this.checked”>'+
-            '<div class=”s-preview-body”>'+
-              '<div class=”s-preview-header”>'+
-                '<span class=”s-badge '+s.type+'”>'+s.label+'</span>'+
-                '<span id=”wprobe-'+i+'” class=”s-probe”><span class=”spinner”></span></span>'+
-              '</div>'+
-              '<input type=”text” value=”'+s.id+'” oninput=”wzSensors['+i+'].id=this.value”>'+
-              '<div class=”s-desc”>'+s.desc+'</div>'+
-            '</div>';
-        list.appendChild(row);
+        const wrap = document.createElement('div');
+        wrap.className = 's3-sensor';
+        wrap.innerHTML =
+            '<div class=”s3-row”>'+
+              '<input type=”checkbox” class=”s3-check” id=”wsen'+i+'” '+(s.enabled?'checked':'')+
+              ' onchange=”wzSensors['+i+'].enabled=this.checked”>'+
+              '<span class=”s-badge '+s.type+'”>'+s.label+'</span>'+
+              '<input type=”text” class=”s3-id” value=”'+s.id+'” oninput=”wzSensors['+i+'].id=this.value”>'+
+              '<span id=”wprobe-'+i+'” class=”s3-status”><span class=”spinner”></span></span>'+
+            '</div>'+
+            '<div class=”s3-desc”>'+s.desc+'</div>';
+        list.appendChild(wrap);
     });
 }
 function wzProbeAll() {
@@ -551,7 +548,7 @@ function wzProbeOne(s, i) {
     if (s.type === 'ping') p.target_ip   = s.target_ip;
     if (s.type === 'upnp') p.target_name = s.target_name;
     if (s.type === 'http') p.url         = s.url;
-    fetch('/api/probe', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(p)})
+    fetch('/api/probe', {method:'POST', headers:{'Content-Type':'application/json','Authorization':'Basic '+btoa('admin:insomnia')}, body:JSON.stringify(p)})
         .then(r => r.json())
         .then(d => {
             const ms = d.latency_ms >= 0 ? ' ' + d.latency_ms + 'ms' : '';

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -8,6 +8,8 @@
 
 #if defined(ARDUINO)
 #include <AsyncEventSource.h>
+#include <ESP32Ping.h>
+#include <HTTPClient.h>
 #include <Update.h>
 #include <WiFi.h>
 #endif

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -99,7 +99,7 @@ void WebServer::setupRoutes() {
         .wz-footer { display:flex; gap:8px; justify-content:space-between; align-items:center; margin-top:20px; padding-top:15px; border-top:1px solid #eee; }
         .wz-footer-right { display:flex; gap:8px; }
         .tv-card { border:2px solid #ddd; border-radius:8px; padding:12px 16px; margin:8px 0; cursor:pointer; display:flex; align-items:center; gap:14px; transition:.15s; }
-        .tv-card:hover { border-color:#4CAF50; background:#f9fff9; }
+        .tv-card:hover { border-color:#90caf9; background:#e3f2fd; }
         .tv-card.selected { border-color:#4CAF50; background:#e8f5e9; }
         .tv-icon { font-size:32px; line-height:1; }
         .tv-name { font-weight:bold; font-size:15px; }

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -130,6 +130,7 @@ void WebServer::setupRoutes() {
         <th>Type</th>
         <th>Value</th>
         <th>Status</th>
+        <th>Actions</th>
       </tr>
     </thead>
     <tbody id="sensor-table-body">
@@ -176,17 +177,28 @@ function openTab(evt, tabName) {
 
 function loadSensors() {
     fetch('/api/sensors').then(r => r.json()).then(data => {
-        console.log('Sensors loaded:', data);
         const tbody = document.getElementById('sensor-table-body');
         tbody.innerHTML = '';
         data.forEach(s => {
             const tr = document.createElement('tr');
             tr.id = 'sensor-row-' + s.id;
-            tr.innerHTML = `<td>${s.id}</td><td>${s.type}</td><td>${s.value}</td><td>${s.available ? '🟢' : '🔴'}</td>`;
+            tr.innerHTML = `<td>${s.id}</td><td>${s.type}</td><td>${s.value}</td><td>${s.available ? '🟢' : '🔴'}</td><td><button onclick="testSensor('${s.id}')">Test</button></td>`;
             tbody.appendChild(tr);
         });
     }).catch(err => {
         console.error('Error loading sensors:', err);
+    });
+}
+
+function testSensor(id) {
+    fetch('/api/sensors/test', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        body: 'id=' + id
+    }).then(r => r.json()).then(data => {
+        alert('Test result for ' + data.id + ': ' + data.value);
+    }).catch(err => {
+        alert('Test failed: ' + err);
     });
 }
 
@@ -263,12 +275,32 @@ document.getElementsByClassName('tablinks')[0].click();
       obj["id"] = sensor->getId();
       obj["type"] = sensor->getType();
       obj["available"] = sensor->isAvailable();
+      // Use config to represent type-specific metadata if needed
       obj["value"] = sensor->read();
     }
     String response;
     serializeJson(doc, response);
     request->send(200, "application/json", response);
   });
+
+  _server.on(
+      "/api/sensors/test", HTTP_POST, [](AsyncWebServerRequest* request) {
+        if (!request->authenticate("admin", "insomnia")) {
+          return request->requestAuthentication();
+        }
+        if (request->hasParam("id", true)) {
+          String id = request->getParam("id", true)->value();
+          auto sensor = SensorManager::instance().getSensor(id.c_str());
+          if (sensor) {
+            bool result = sensor->read();
+            String response = "{\"id\":\"" + id + "\", \"value\":" +
+                              (result ? "true" : "false") + "}";
+            request->send(200, "application/json", response);
+            return;
+          }
+        }
+        request->send(404, "application/json", "{\"error\":\"Not found\"}");
+      });
 
   _server.on(
       "/update", HTTP_POST,

--- a/src/web/WebServer.h
+++ b/src/web/WebServer.h
@@ -8,6 +8,7 @@
 #include <ESPAsyncWebServer.h>
 #endif
 
+#include "../config/ConfigManager.h"
 #include "../discovery/SamsungTvDiscovery.h"
 
 namespace InsomniaTV {
@@ -16,24 +17,27 @@ namespace InsomniaTV {
  * @brief Handles web interface and API routes for insomniaTV.
  */
 class WebServer {
-public:
+ public:
   /**
    * @brief Constructs the WebServer.
    * @param port The server port.
    * @param discovery Reference to the TV discovery service.
+   * @param configMgr Reference to the ConfigManager.
    */
-  WebServer(uint16_t port, SamsungTvDiscovery& discovery);
+  WebServer(uint16_t port, SamsungTvDiscovery& discovery,
+            ConfigManager& configMgr);
 
   /**
    * @brief Starts the web server.
    */
   void begin();
 
-private:
+ private:
 #if defined(ARDUINO)
   AsyncWebServer _server;
 #endif
   SamsungTvDiscovery& _discovery;
+  ConfigManager& _configMgr;
   void setupRoutes();
 };
 

--- a/src/web/WebServer.h
+++ b/src/web/WebServer.h
@@ -17,7 +17,7 @@ namespace InsomniaTV {
  * @brief Handles web interface and API routes for insomniaTV.
  */
 class WebServer {
- public:
+public:
   /**
    * @brief Constructs the WebServer.
    * @param port The server port.
@@ -32,7 +32,7 @@ class WebServer {
    */
   void begin();
 
- private:
+private:
 #if defined(ARDUINO)
   AsyncWebServer _server;
 #endif

--- a/test/test_config/test_config.cpp
+++ b/test/test_config/test_config.cpp
@@ -351,6 +351,25 @@ void test_config_json_logic(void) {
 // ---------------------------------------------------------------------------
 // Unity entry point
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// Test: Sensor JSON persistence
+// ---------------------------------------------------------------------------
+void test_config_sensors_json(void) {
+  TestConfigManager mgr;
+  mgr.resetToDefaults();
+  InsomniaTV::Config cfg = mgr.get();
+  cfg.sensorsJson = "[{\"id\":\"test\",\"type\":\"gpio_input\"}]";
+  mgr.set(cfg);
+
+  std::string json = mgr.testToJson(cfg);
+  TEST_ASSERT_NOT_EQUAL(std::string::npos, json.find("sensors"));
+  TEST_ASSERT_NOT_EQUAL(std::string::npos, json.find("gpio_input"));
+
+  InsomniaTV::Config next;
+  TEST_ASSERT_TRUE(mgr.testParseJson(json, next));
+  TEST_ASSERT_EQUAL_STRING(cfg.sensorsJson.c_str(), next.sensorsJson.c_str());
+}
+
 int runUnityTests(void) {
   UNITY_BEGIN();
   RUN_TEST(test_config_defaults);
@@ -369,6 +388,7 @@ int runUnityTests(void) {
   RUN_TEST(test_config_save_returns_ok);
   RUN_TEST(test_config_json_roundtrip);
   RUN_TEST(test_config_json_logic);
+  RUN_TEST(test_config_sensors_json);
   return UNITY_END();
 }
 

--- a/test/test_sensors/test_sensors.cpp
+++ b/test/test_sensors/test_sensors.cpp
@@ -12,6 +12,7 @@ using namespace InsomniaTV;
 
 void test_sensor_manager_registry() {
     auto& mgr = SensorManager::instance();
+    mgr.clear();
     auto sensor = std::make_shared<GpioInputSensor>("test_gpio", 5);
 
     mgr.registerSensor(sensor);
@@ -20,6 +21,37 @@ void test_sensor_manager_registry() {
     TEST_ASSERT_NOT_NULL(retrieved.get());
     TEST_ASSERT_EQUAL_STRING("test_gpio", retrieved->getId().c_str());
     TEST_ASSERT_EQUAL_STRING("gpio_input", retrieved->getType().c_str());
+}
+
+void test_sensor_manager_lifecycle() {
+    auto& mgr = SensorManager::instance();
+    mgr.clear();
+
+    auto s1 = std::make_shared<GpioInputSensor>("s1", 1);
+    auto s2 = std::make_shared<GpioInputSensor>("s2", 2);
+
+    mgr.registerSensor(s1);
+    mgr.registerSensor(s2);
+    TEST_ASSERT_EQUAL(2, mgr.listSensors().size());
+
+    mgr.removeSensor("s1");
+    TEST_ASSERT_EQUAL(1, mgr.listSensors().size());
+    TEST_ASSERT_NULL(mgr.getSensor("s1").get());
+    TEST_ASSERT_NOT_NULL(mgr.getSensor("s2").get());
+
+    mgr.clear();
+    TEST_ASSERT_EQUAL(0, mgr.listSensors().size());
+}
+
+void test_sensor_state_machine() {
+    GpioInputSensor sensor("state_test", 10);
+    TEST_ASSERT_TRUE(sensor.getState() == Sensor::State::UNINITIALIZED);
+
+    sensor.setState(Sensor::State::READY);
+    TEST_ASSERT_TRUE(sensor.isAvailable());
+
+    sensor.setState(Sensor::State::ERROR);
+    TEST_ASSERT_FALSE(sensor.isAvailable());
 }
 
 void test_gpio_input_sensor() {
@@ -49,6 +81,8 @@ void test_http_sensor() {
 int main() {
     UNITY_BEGIN();
     RUN_TEST(test_sensor_manager_registry);
+    RUN_TEST(test_sensor_manager_lifecycle);
+    RUN_TEST(test_sensor_state_machine);
     RUN_TEST(test_gpio_input_sensor);
     RUN_TEST(test_gpio_analog_sensor);
     RUN_TEST(test_ping_sensor);

--- a/test/test_sensors/test_sensors.cpp
+++ b/test/test_sensors/test_sensors.cpp
@@ -1,0 +1,57 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#include <unity.h>
+#include <memory>
+#include "../../src/sensors/SensorManager.h"
+#include "../../src/sensors/GpioInputSensor.h"
+#include "../../src/sensors/GpioAnalogSensor.h"
+#include "../../src/sensors/PingSensor.h"
+#include "../../src/sensors/HttpSensor.h"
+
+using namespace InsomniaTV;
+
+void test_sensor_manager_registry() {
+    auto& mgr = SensorManager::instance();
+    auto sensor = std::make_shared<GpioInputSensor>("test_gpio", 5);
+
+    mgr.registerSensor(sensor);
+
+    auto retrieved = mgr.getSensor("test_gpio");
+    TEST_ASSERT_NOT_NULL(retrieved.get());
+    TEST_ASSERT_EQUAL_STRING("test_gpio", retrieved->getId().c_str());
+    TEST_ASSERT_EQUAL_STRING("gpio_input", retrieved->getType().c_str());
+}
+
+void test_gpio_input_sensor() {
+    GpioInputSensor sensor("gpio1", 10, true);
+    TEST_ASSERT_EQUAL_STRING("gpio1", sensor.getId().c_str());
+
+    JsonDocument cfg = sensor.getConfig();
+    TEST_ASSERT_EQUAL(10, cfg["pin"]);
+    TEST_ASSERT_TRUE(cfg["pullup"]);
+}
+
+void test_gpio_analog_sensor() {
+    GpioAnalogSensor sensor("analog1", 34);
+    TEST_ASSERT_EQUAL_STRING("analog1", sensor.getId().c_str());
+}
+
+void test_ping_sensor() {
+    PingSensor sensor("ping1", "192.168.1.1");
+    TEST_ASSERT_EQUAL_STRING("ping1", sensor.getId().c_str());
+}
+
+void test_http_sensor() {
+    HttpSensor sensor("http1", "http://example.com");
+    TEST_ASSERT_EQUAL_STRING("http1", sensor.getId().c_str());
+}
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_sensor_manager_registry);
+    RUN_TEST(test_gpio_input_sensor);
+    RUN_TEST(test_gpio_analog_sensor);
+    RUN_TEST(test_ping_sensor);
+    RUN_TEST(test_http_sensor);
+    return UNITY_END();
+}

--- a/test/test_sensors/test_sensors.cpp
+++ b/test/test_sensors/test_sensors.cpp
@@ -1,12 +1,14 @@
 // Copyright 2026 insomniaTV Contributors. All rights reserved.
 
 #include <unity.h>
+
 #include <memory>
-#include "../../src/sensors/SensorManager.h"
-#include "../../src/sensors/GpioInputSensor.h"
+
 #include "../../src/sensors/GpioAnalogSensor.h"
-#include "../../src/sensors/PingSensor.h"
+#include "../../src/sensors/GpioInputSensor.h"
 #include "../../src/sensors/HttpSensor.h"
+#include "../../src/sensors/PingSensor.h"
+#include "../../src/sensors/SensorManager.h"
 
 using InsomniaTV::GpioAnalogSensor;
 using InsomniaTV::GpioInputSensor;
@@ -16,81 +18,81 @@ using InsomniaTV::Sensor;
 using InsomniaTV::SensorManager;
 
 void test_sensor_manager_registry() {
-    auto& mgr = SensorManager::instance();
-    mgr.clear();
-    auto sensor = std::make_shared<GpioInputSensor>("test_gpio", 5);
+  auto& mgr = SensorManager::instance();
+  mgr.clear();
+  auto sensor = std::make_shared<GpioInputSensor>("test_gpio", 5);
 
-    mgr.registerSensor(sensor);
+  mgr.registerSensor(sensor);
 
-    auto retrieved = mgr.getSensor("test_gpio");
-    TEST_ASSERT_NOT_NULL(retrieved.get());
-    TEST_ASSERT_EQUAL_STRING("test_gpio", retrieved->getId().c_str());
-    TEST_ASSERT_EQUAL_STRING("gpio_input", retrieved->getType().c_str());
+  auto retrieved = mgr.getSensor("test_gpio");
+  TEST_ASSERT_NOT_NULL(retrieved.get());
+  TEST_ASSERT_EQUAL_STRING("test_gpio", retrieved->getId().c_str());
+  TEST_ASSERT_EQUAL_STRING("gpio_input", retrieved->getType().c_str());
 }
 
 void test_sensor_manager_lifecycle() {
-    auto& mgr = SensorManager::instance();
-    mgr.clear();
+  auto& mgr = SensorManager::instance();
+  mgr.clear();
 
-    auto s1 = std::make_shared<GpioInputSensor>("s1", 1);
-    auto s2 = std::make_shared<GpioInputSensor>("s2", 2);
+  auto s1 = std::make_shared<GpioInputSensor>("s1", 1);
+  auto s2 = std::make_shared<GpioInputSensor>("s2", 2);
 
-    mgr.registerSensor(s1);
-    mgr.registerSensor(s2);
-    TEST_ASSERT_EQUAL(2, mgr.listSensors().size());
+  mgr.registerSensor(s1);
+  mgr.registerSensor(s2);
+  TEST_ASSERT_EQUAL(2, mgr.listSensors().size());
 
-    mgr.removeSensor("s1");
-    TEST_ASSERT_EQUAL(1, mgr.listSensors().size());
-    TEST_ASSERT_NULL(mgr.getSensor("s1").get());
-    TEST_ASSERT_NOT_NULL(mgr.getSensor("s2").get());
+  mgr.removeSensor("s1");
+  TEST_ASSERT_EQUAL(1, mgr.listSensors().size());
+  TEST_ASSERT_NULL(mgr.getSensor("s1").get());
+  TEST_ASSERT_NOT_NULL(mgr.getSensor("s2").get());
 
-    mgr.clear();
-    TEST_ASSERT_EQUAL(0, mgr.listSensors().size());
+  mgr.clear();
+  TEST_ASSERT_EQUAL(0, mgr.listSensors().size());
 }
 
 void test_sensor_state_machine() {
-    GpioInputSensor sensor("state_test", 10);
-    TEST_ASSERT_TRUE(sensor.getState() == Sensor::State::UNINITIALIZED);
+  GpioInputSensor sensor("state_test", 10);
+  TEST_ASSERT_TRUE(sensor.getState() == Sensor::State::UNINITIALIZED);
 
-    sensor.setState(Sensor::State::READY);
-    TEST_ASSERT_TRUE(sensor.isAvailable());
+  sensor.setState(Sensor::State::READY);
+  TEST_ASSERT_TRUE(sensor.isAvailable());
 
-    sensor.setState(Sensor::State::ERROR);
-    TEST_ASSERT_FALSE(sensor.isAvailable());
+  sensor.setState(Sensor::State::ERROR);
+  TEST_ASSERT_FALSE(sensor.isAvailable());
 }
 
 void test_gpio_input_sensor() {
-    GpioInputSensor sensor("gpio1", 10, true);
-    TEST_ASSERT_EQUAL_STRING("gpio1", sensor.getId().c_str());
+  GpioInputSensor sensor("gpio1", 10, true);
+  TEST_ASSERT_EQUAL_STRING("gpio1", sensor.getId().c_str());
 
-    JsonDocument cfg = sensor.getConfig();
-    TEST_ASSERT_EQUAL(10, cfg["pin"]);
-    TEST_ASSERT_TRUE(cfg["pullup"]);
+  JsonDocument cfg = sensor.getConfig();
+  TEST_ASSERT_EQUAL(10, cfg["pin"]);
+  TEST_ASSERT_TRUE(cfg["pullup"]);
 }
 
 void test_gpio_analog_sensor() {
-    GpioAnalogSensor sensor("analog1", 34);
-    TEST_ASSERT_EQUAL_STRING("analog1", sensor.getId().c_str());
+  GpioAnalogSensor sensor("analog1", 34);
+  TEST_ASSERT_EQUAL_STRING("analog1", sensor.getId().c_str());
 }
 
 void test_ping_sensor() {
-    PingSensor sensor("ping1", "192.168.1.1");
-    TEST_ASSERT_EQUAL_STRING("ping1", sensor.getId().c_str());
+  PingSensor sensor("ping1", "192.168.1.1");
+  TEST_ASSERT_EQUAL_STRING("ping1", sensor.getId().c_str());
 }
 
 void test_http_sensor() {
-    HttpSensor sensor("http1", "http://example.com");
-    TEST_ASSERT_EQUAL_STRING("http1", sensor.getId().c_str());
+  HttpSensor sensor("http1", "http://example.com");
+  TEST_ASSERT_EQUAL_STRING("http1", sensor.getId().c_str());
 }
 
 int main() {
-    UNITY_BEGIN();
-    RUN_TEST(test_sensor_manager_registry);
-    RUN_TEST(test_sensor_manager_lifecycle);
-    RUN_TEST(test_sensor_state_machine);
-    RUN_TEST(test_gpio_input_sensor);
-    RUN_TEST(test_gpio_analog_sensor);
-    RUN_TEST(test_ping_sensor);
-    RUN_TEST(test_http_sensor);
-    return UNITY_END();
+  UNITY_BEGIN();
+  RUN_TEST(test_sensor_manager_registry);
+  RUN_TEST(test_sensor_manager_lifecycle);
+  RUN_TEST(test_sensor_state_machine);
+  RUN_TEST(test_gpio_input_sensor);
+  RUN_TEST(test_gpio_analog_sensor);
+  RUN_TEST(test_ping_sensor);
+  RUN_TEST(test_http_sensor);
+  return UNITY_END();
 }

--- a/test/test_sensors/test_sensors.cpp
+++ b/test/test_sensors/test_sensors.cpp
@@ -8,7 +8,12 @@
 #include "../../src/sensors/PingSensor.h"
 #include "../../src/sensors/HttpSensor.h"
 
-using namespace InsomniaTV;
+using InsomniaTV::GpioAnalogSensor;
+using InsomniaTV::GpioInputSensor;
+using InsomniaTV::HttpSensor;
+using InsomniaTV::PingSensor;
+using InsomniaTV::Sensor;
+using InsomniaTV::SensorManager;
 
 void test_sensor_manager_registry() {
     auto& mgr = SensorManager::instance();

--- a/test/test_state/test_state.cpp
+++ b/test/test_state/test_state.cpp
@@ -2,24 +2,108 @@
 
 #include <unity.h>
 
+#include "../../src/hal/IClock.h"
 #include "../../src/state/RampScheduler.h"
 #include "../../src/state/SleepStateMachine.h"
 
+using InsomniaTV::IClock;
 using InsomniaTV::RampScheduler;
 using InsomniaTV::SleepStateMachine;
 using InsomniaTV::State;
 
+// ---------------------------------------------------------------------------
+// Minimal clock mock
+// ---------------------------------------------------------------------------
+class MockClock : public IClock {
+ public:
+  uint32_t nowMs() const override { return ms_; }
+  void advanceMs(uint32_t ms) override { ms_ += ms; }
+  uint32_t ms_ = 0;
+};
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
 void test_state_machine_initial_state() {
-  SleepStateMachine sm;
+  MockClock clk;
+  SleepStateMachine sm(clk);
   TEST_ASSERT_EQUAL(State::MONITORING, sm.getCurrentState());
 }
 
+// ---------------------------------------------------------------------------
+// IR activity resets to MONITORING
+// ---------------------------------------------------------------------------
 void test_state_machine_activity_reset() {
-  SleepStateMachine sm;
+  MockClock clk;
+  SleepStateMachine sm(clk);
   sm.onIrActivity();
   TEST_ASSERT_EQUAL(State::MONITORING, sm.getCurrentState());
 }
 
+// ---------------------------------------------------------------------------
+// Inactivity timeout triggers RAMPING
+// ---------------------------------------------------------------------------
+void test_state_machine_inactivity_to_ramping() {
+  MockClock clk;
+  SleepStateMachine sm(clk, /*inactivityTimeoutMs=*/5000);
+  clk.advanceMs(4999);
+  sm.tick();
+  TEST_ASSERT_EQUAL(State::MONITORING, sm.getCurrentState());
+
+  clk.advanceMs(1);
+  sm.tick();
+  TEST_ASSERT_EQUAL(State::RAMPING, sm.getCurrentState());
+}
+
+// ---------------------------------------------------------------------------
+// IR activity during RAMPING resets to MONITORING
+// ---------------------------------------------------------------------------
+void test_state_machine_ir_during_ramping() {
+  MockClock clk;
+  SleepStateMachine sm(clk, 5000);
+  clk.advanceMs(6000);
+  sm.tick();
+  TEST_ASSERT_EQUAL(State::RAMPING, sm.getCurrentState());
+
+  sm.onIrActivity();
+  TEST_ASSERT_EQUAL(State::MONITORING, sm.getCurrentState());
+}
+
+// ---------------------------------------------------------------------------
+// onRampComplete transitions RAMPING → VERIFYING
+// ---------------------------------------------------------------------------
+void test_state_machine_ramp_complete_to_verifying() {
+  MockClock clk;
+  SleepStateMachine sm(clk, 5000);
+  clk.advanceMs(6000);
+  sm.tick();
+  TEST_ASSERT_EQUAL(State::RAMPING, sm.getCurrentState());
+
+  sm.onRampComplete();
+  TEST_ASSERT_EQUAL(State::VERIFYING, sm.getCurrentState());
+}
+
+// ---------------------------------------------------------------------------
+// VERIFYING without TvStateMachine → fires power-off, returns MONITORING
+// ---------------------------------------------------------------------------
+void test_state_machine_verifying_no_tv_sm() {
+  MockClock clk;
+  SleepStateMachine sm(clk, 5000);
+  int powerOffCalls = 0;
+  sm.setPowerOffCallback([&] { powerOffCalls++; });
+
+  clk.advanceMs(6000);
+  sm.tick();                    // → RAMPING
+  sm.onRampComplete();          // → VERIFYING
+  sm.tick();                    // → fires callback, → MONITORING
+
+  TEST_ASSERT_EQUAL(1, powerOffCalls);
+  TEST_ASSERT_EQUAL(State::MONITORING, sm.getCurrentState());
+}
+
+// ---------------------------------------------------------------------------
+// RampScheduler can be constructed and toggled (stubs)
+// ---------------------------------------------------------------------------
 void test_ramp_scheduler_init() {
   auto on_step = []() {};
   RampScheduler rs(1000, on_step);
@@ -32,6 +116,10 @@ int main() {
   UNITY_BEGIN();
   RUN_TEST(test_state_machine_initial_state);
   RUN_TEST(test_state_machine_activity_reset);
+  RUN_TEST(test_state_machine_inactivity_to_ramping);
+  RUN_TEST(test_state_machine_ir_during_ramping);
+  RUN_TEST(test_state_machine_ramp_complete_to_verifying);
+  RUN_TEST(test_state_machine_verifying_no_tv_sm);
   RUN_TEST(test_ramp_scheduler_init);
   return UNITY_END();
 }

--- a/test/test_state/test_state.cpp
+++ b/test/test_state/test_state.cpp
@@ -15,7 +15,7 @@ using InsomniaTV::State;
 // Minimal clock mock
 // ---------------------------------------------------------------------------
 class MockClock : public IClock {
- public:
+public:
   uint32_t nowMs() const override { return ms_; }
   void advanceMs(uint32_t ms) override { ms_ += ms; }
   uint32_t ms_ = 0;
@@ -93,9 +93,9 @@ void test_state_machine_verifying_no_tv_sm() {
   sm.setPowerOffCallback([&] { powerOffCalls++; });
 
   clk.advanceMs(6000);
-  sm.tick();                    // → RAMPING
-  sm.onRampComplete();          // → VERIFYING
-  sm.tick();                    // → fires callback, → MONITORING
+  sm.tick();            // → RAMPING
+  sm.onRampComplete();  // → VERIFYING
+  sm.tick();            // → fires callback, → MONITORING
 
   TEST_ASSERT_EQUAL(1, powerOffCalls);
   TEST_ASSERT_EQUAL(State::MONITORING, sm.getCurrentState());

--- a/test/test_tv/test_tv.cpp
+++ b/test/test_tv/test_tv.cpp
@@ -5,10 +5,16 @@
 #include <memory>
 #include <string>
 
+#include "../../src/hal/IClock.h"
 #include "../../src/sensors/SensorManager.h"
+#include "../../src/state/SleepStateMachine.h"
 #include "../../src/tv/TvStateMachine.h"
 
-using namespace InsomniaTV;
+using InsomniaTV::IClock;
+using InsomniaTV::Sensor;
+using InsomniaTV::SensorManager;
+using InsomniaTV::SleepStateMachine;
+using InsomniaTV::TvStateMachine;
 
 // ---------------------------------------------------------------------------
 // Controllable sensor mock
@@ -280,16 +286,14 @@ void test_sleep_sm_verifying_tv_on_fires_poweroff() {
   tvSm.onSensorUpdate("s1", true);  // TV is ON
 
   // Now wire into SleepStateMachine
-  InsomniaTV::IClock* clkPtr = nullptr;
-  // Use a simple inline mock
-  class SimpleClock : public InsomniaTV::IClock {
+  class SimpleClock : public IClock {
    public:
     uint32_t nowMs() const override { return ms_; }
     void advanceMs(uint32_t ms) override { ms_ += ms; }
     uint32_t ms_ = 0;
   } clk;
 
-  InsomniaTV::SleepStateMachine sleepSm(clk, 1000);
+  SleepStateMachine sleepSm(clk, 1000);
   sleepSm.setTvStateMachine(&tvSm);
 
   int powerOffCalls = 0;
@@ -316,14 +320,14 @@ void test_sleep_sm_verifying_tv_already_off() {
   tvSm.begin(cfg);
   tvSm.onSensorUpdate("s1", false);  // TV is OFF
 
-  class SimpleClock : public InsomniaTV::IClock {
+  class SimpleClock : public IClock {
    public:
     uint32_t nowMs() const override { return ms_; }
     void advanceMs(uint32_t ms) override { ms_ += ms; }
     uint32_t ms_ = 0;
   } clk;
 
-  InsomniaTV::SleepStateMachine sleepSm(clk, 1000);
+  SleepStateMachine sleepSm(clk, 1000);
   sleepSm.setTvStateMachine(&tvSm);
 
   int powerOffCalls = 0;
@@ -349,14 +353,14 @@ void test_sleep_sm_verifying_tv_unknown_fallback() {
   JsonDocument cfg = makeConfig(99, {{"s1", 5, true}});
   tvSm.begin(cfg);
 
-  class SimpleClock : public InsomniaTV::IClock {
+  class SimpleClock : public IClock {
    public:
     uint32_t nowMs() const override { return ms_; }
     void advanceMs(uint32_t ms) override { ms_ += ms; }
     uint32_t ms_ = 0;
   } clk;
 
-  InsomniaTV::SleepStateMachine sleepSm(clk, 1000);
+  SleepStateMachine sleepSm(clk, 1000);
   sleepSm.setTvStateMachine(&tvSm);
 
   int powerOffCalls = 0;

--- a/test/test_tv/test_tv.cpp
+++ b/test/test_tv/test_tv.cpp
@@ -20,7 +20,7 @@ using InsomniaTV::TvStateMachine;
 // Controllable sensor mock
 // ---------------------------------------------------------------------------
 class MockSensor : public Sensor {
- public:
+public:
   MockSensor(const std::string& id, const std::string& type, bool value = false)
       : id_(id), type_(type), value_(value) {
     state_ = State::READY;
@@ -34,7 +34,7 @@ class MockSensor : public Sensor {
 
   void setValue(bool v) { value_ = v; }
 
- private:
+private:
   std::string id_;
   std::string type_;
   bool value_;
@@ -201,8 +201,7 @@ void test_tv_sm_get_contributions() {
   mgr.clear();
   TvStateMachine sm(mgr, 1);
 
-  JsonDocument cfg =
-      makeConfig(1, {{"ping1", 3, true}, {"upnp1", 5, false}});
+  JsonDocument cfg = makeConfig(1, {{"ping1", 3, true}, {"upnp1", 5, false}});
   sm.begin(cfg);
 
   sm.onSensorUpdate("ping1", true);
@@ -287,7 +286,7 @@ void test_sleep_sm_verifying_tv_on_fires_poweroff() {
 
   // Now wire into SleepStateMachine
   class SimpleClock : public IClock {
-   public:
+  public:
     uint32_t nowMs() const override { return ms_; }
     void advanceMs(uint32_t ms) override { ms_ += ms; }
     uint32_t ms_ = 0;
@@ -300,9 +299,9 @@ void test_sleep_sm_verifying_tv_on_fires_poweroff() {
   sleepSm.setPowerOffCallback([&] { powerOffCalls++; });
 
   clk.advanceMs(2000);
-  sleepSm.tick();          // MONITORING → RAMPING
+  sleepSm.tick();            // MONITORING → RAMPING
   sleepSm.onRampComplete();  // RAMPING → VERIFYING
-  sleepSm.tick();          // VERIFYING → POWERING_OFF → MONITORING
+  sleepSm.tick();            // VERIFYING → POWERING_OFF → MONITORING
 
   TEST_ASSERT_EQUAL(1, powerOffCalls);
   TEST_ASSERT_EQUAL(InsomniaTV::State::MONITORING, sleepSm.getCurrentState());
@@ -321,7 +320,7 @@ void test_sleep_sm_verifying_tv_already_off() {
   tvSm.onSensorUpdate("s1", false);  // TV is OFF
 
   class SimpleClock : public IClock {
-   public:
+  public:
     uint32_t nowMs() const override { return ms_; }
     void advanceMs(uint32_t ms) override { ms_ += ms; }
     uint32_t ms_ = 0;
@@ -354,7 +353,7 @@ void test_sleep_sm_verifying_tv_unknown_fallback() {
   tvSm.begin(cfg);
 
   class SimpleClock : public IClock {
-   public:
+  public:
     uint32_t nowMs() const override { return ms_; }
     void advanceMs(uint32_t ms) override { ms_ += ms; }
     uint32_t ms_ = 0;

--- a/test/test_tv/test_tv.cpp
+++ b/test/test_tv/test_tv.cpp
@@ -301,7 +301,7 @@ void test_sleep_sm_verifying_tv_on_fires_poweroff() {
 
   clk.advanceMs(2000);
   sleepSm.tick();          // MONITORING → RAMPING
-  sleepSm.onRampComplete(); // RAMPING → VERIFYING
+  sleepSm.onRampComplete();  // RAMPING → VERIFYING
   sleepSm.tick();          // VERIFYING → POWERING_OFF → MONITORING
 
   TEST_ASSERT_EQUAL(1, powerOffCalls);

--- a/test/test_tv/test_tv.cpp
+++ b/test/test_tv/test_tv.cpp
@@ -1,0 +1,394 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#include <unity.h>
+
+#include <memory>
+#include <string>
+
+#include "../../src/sensors/SensorManager.h"
+#include "../../src/tv/TvStateMachine.h"
+
+using namespace InsomniaTV;
+
+// ---------------------------------------------------------------------------
+// Controllable sensor mock
+// ---------------------------------------------------------------------------
+class MockSensor : public Sensor {
+ public:
+  MockSensor(const std::string& id, const std::string& type, bool value = false)
+      : id_(id), type_(type), value_(value) {
+    state_ = State::READY;
+  }
+
+  std::string getId() const override { return id_; }
+  std::string getType() const override { return type_; }
+  bool read() override { return value_; }
+  JsonDocument getConfig() override { return JsonDocument(); }
+  void setConfig(const JsonDocument&) override {}
+
+  void setValue(bool v) { value_ = v; }
+
+ private:
+  std::string id_;
+  std::string type_;
+  bool value_;
+};
+
+// Helper: build TvStateMachine config from a list of {id, weight, enabled}.
+static JsonDocument makeConfig(
+    int hysteresis,
+    std::initializer_list<std::tuple<const char*, int, bool>> sensors) {
+  JsonDocument doc;
+  doc["hysteresis_count"] = hysteresis;
+  JsonArray arr = doc["detection_sensors"].to<JsonArray>();
+  for (auto& [id, w, en] : sensors) {
+    JsonObject o = arr.add<JsonObject>();
+    o["sensor_id"] = id;
+    o["weight"] = w;
+    o["enabled"] = en;
+  }
+  return doc;
+}
+
+// ---------------------------------------------------------------------------
+// Initial state is UNKNOWN
+// ---------------------------------------------------------------------------
+void test_tv_sm_initial_state() {
+  SensorManager& mgr = SensorManager::instance();
+  mgr.clear();
+  TvStateMachine sm(mgr);
+  TEST_ASSERT_EQUAL(TvStateMachine::PowerState::UNKNOWN, sm.getPowerState());
+}
+
+// ---------------------------------------------------------------------------
+// Single sensor ON → confidence = +10, after 2 updates → ON
+// ---------------------------------------------------------------------------
+void test_tv_sm_single_sensor_on() {
+  SensorManager& mgr = SensorManager::instance();
+  mgr.clear();
+  TvStateMachine sm(mgr, /*hysteresis=*/2);
+
+  JsonDocument cfg = makeConfig(2, {{"s1", 3, true}});
+  sm.begin(cfg);
+
+  // Simulate two consecutive ON readings (hysteresis = 2)
+  sm.onSensorUpdate("s1", true);
+  TEST_ASSERT_EQUAL(TvStateMachine::PowerState::UNKNOWN, sm.getPowerState());
+  sm.onSensorUpdate("s1", true);
+  TEST_ASSERT_EQUAL(TvStateMachine::PowerState::ON, sm.getPowerState());
+}
+
+// ---------------------------------------------------------------------------
+// Single sensor OFF → confidence = -10, after 2 updates → OFF
+// ---------------------------------------------------------------------------
+void test_tv_sm_single_sensor_off() {
+  SensorManager& mgr = SensorManager::instance();
+  mgr.clear();
+  TvStateMachine sm(mgr, 2);
+
+  JsonDocument cfg = makeConfig(2, {{"s1", 3, true}});
+  sm.begin(cfg);
+
+  sm.onSensorUpdate("s1", false);
+  sm.onSensorUpdate("s1", false);
+  TEST_ASSERT_EQUAL(TvStateMachine::PowerState::OFF, sm.getPowerState());
+}
+
+// ---------------------------------------------------------------------------
+// Weighted fusion: two ON sensors outweigh one OFF sensor
+// ---------------------------------------------------------------------------
+void test_tv_sm_weighted_fusion_on_wins() {
+  SensorManager& mgr = SensorManager::instance();
+  mgr.clear();
+  TvStateMachine sm(mgr, 1);  // hysteresis=1 for simplicity
+
+  // s1 weight=3 ON (+3), s2 weight=1 OFF (-1) → net=+2, confidence=+5 → ON
+  JsonDocument cfg = makeConfig(1, {{"s1", 3, true}, {"s2", 1, true}});
+  sm.begin(cfg);
+
+  sm.onSensorUpdate("s1", true);
+  sm.onSensorUpdate("s2", false);
+  TEST_ASSERT_EQUAL(TvStateMachine::PowerState::ON, sm.getPowerState());
+}
+
+// ---------------------------------------------------------------------------
+// Balanced sensors → UNKNOWN (confidence in -3..+3)
+// ---------------------------------------------------------------------------
+void test_tv_sm_balanced_sensors_unknown() {
+  SensorManager& mgr = SensorManager::instance();
+  mgr.clear();
+  TvStateMachine sm(mgr, 1);
+
+  // equal weight ON + OFF → confidence = 0 → UNKNOWN
+  JsonDocument cfg = makeConfig(1, {{"s1", 2, true}, {"s2", 2, true}});
+  sm.begin(cfg);
+
+  sm.onSensorUpdate("s1", true);
+  sm.onSensorUpdate("s2", false);
+  TEST_ASSERT_EQUAL(TvStateMachine::PowerState::UNKNOWN, sm.getPowerState());
+}
+
+// ---------------------------------------------------------------------------
+// Hysteresis: inconsistent readings prevent state change
+// ---------------------------------------------------------------------------
+void test_tv_sm_hysteresis_prevents_flapping() {
+  SensorManager& mgr = SensorManager::instance();
+  mgr.clear();
+  TvStateMachine sm(mgr, /*hysteresis=*/3);
+
+  JsonDocument cfg = makeConfig(3, {{"s1", 5, true}});
+  sm.begin(cfg);
+
+  // Two ON readings — not enough (need 3)
+  sm.onSensorUpdate("s1", true);
+  sm.onSensorUpdate("s1", true);
+  TEST_ASSERT_EQUAL(TvStateMachine::PowerState::UNKNOWN, sm.getPowerState());
+
+  // Break the streak with an OFF, then two more ON — reset counter
+  sm.onSensorUpdate("s1", false);
+  sm.onSensorUpdate("s1", true);
+  sm.onSensorUpdate("s1", true);
+  TEST_ASSERT_EQUAL(TvStateMachine::PowerState::UNKNOWN, sm.getPowerState());
+
+  // Third consecutive ON → state changes
+  sm.onSensorUpdate("s1", true);
+  TEST_ASSERT_EQUAL(TvStateMachine::PowerState::ON, sm.getPowerState());
+}
+
+// ---------------------------------------------------------------------------
+// Subscriber callback fires exactly once per state transition
+// ---------------------------------------------------------------------------
+void test_tv_sm_subscriber_callback() {
+  SensorManager& mgr = SensorManager::instance();
+  mgr.clear();
+  TvStateMachine sm(mgr, 1);
+
+  int callbackCount = 0;
+  TvStateMachine::PowerState lastState = TvStateMachine::PowerState::UNKNOWN;
+  sm.subscribe([&](TvStateMachine::PowerState ps) {
+    callbackCount++;
+    lastState = ps;
+  });
+
+  JsonDocument cfg = makeConfig(1, {{"s1", 4, true}});
+  sm.begin(cfg);
+
+  sm.onSensorUpdate("s1", true);
+  TEST_ASSERT_EQUAL(1, callbackCount);
+  TEST_ASSERT_EQUAL(TvStateMachine::PowerState::ON, lastState);
+
+  // Same vote again — no additional callback
+  sm.onSensorUpdate("s1", true);
+  TEST_ASSERT_EQUAL(1, callbackCount);
+
+  // Transition to OFF
+  sm.onSensorUpdate("s1", false);
+  TEST_ASSERT_EQUAL(2, callbackCount);
+  TEST_ASSERT_EQUAL(TvStateMachine::PowerState::OFF, lastState);
+}
+
+// ---------------------------------------------------------------------------
+// getContributions() reflects each sensor's current vote
+// ---------------------------------------------------------------------------
+void test_tv_sm_get_contributions() {
+  SensorManager& mgr = SensorManager::instance();
+  mgr.clear();
+  TvStateMachine sm(mgr, 1);
+
+  JsonDocument cfg =
+      makeConfig(1, {{"ping1", 3, true}, {"upnp1", 5, false}});
+  sm.begin(cfg);
+
+  sm.onSensorUpdate("ping1", true);
+
+  auto contribs = sm.getContributions();
+  TEST_ASSERT_EQUAL(2, contribs.size());
+
+  // ping1: enabled, available, ON → vote = +3
+  TEST_ASSERT_EQUAL_STRING("ping1", contribs[0].sensorId.c_str());
+  TEST_ASSERT_TRUE(contribs[0].enabled);
+  TEST_ASSERT_TRUE(contribs[0].available);
+  TEST_ASSERT_TRUE(contribs[0].rawValue);
+  TEST_ASSERT_EQUAL_INT(3, contribs[0].weightedVote);
+
+  // upnp1: disabled → vote = 0
+  TEST_ASSERT_EQUAL_STRING("upnp1", contribs[1].sensorId.c_str());
+  TEST_ASSERT_FALSE(contribs[1].enabled);
+  TEST_ASSERT_EQUAL_INT(0, contribs[1].weightedVote);
+}
+
+// ---------------------------------------------------------------------------
+// sendPowerCommand() fires callback and sets TRANSITIONING
+// ---------------------------------------------------------------------------
+void test_tv_sm_send_power_command() {
+  SensorManager& mgr = SensorManager::instance();
+  mgr.clear();
+  TvStateMachine sm(mgr, 1);
+
+  bool commandSent = false;
+  bool commandValue = false;
+  sm.setPowerCommandCallback([&](bool on) {
+    commandSent = true;
+    commandValue = on;
+  });
+
+  TEST_ASSERT_TRUE(sm.sendPowerCommand(false));
+  TEST_ASSERT_TRUE(commandSent);
+  TEST_ASSERT_FALSE(commandValue);
+  TEST_ASSERT_EQUAL(TvStateMachine::PowerState::TRANSITIONING,
+                    sm.getPowerState());
+}
+
+// ---------------------------------------------------------------------------
+// sendPowerCommand() returns false when no callback is set
+// ---------------------------------------------------------------------------
+void test_tv_sm_send_power_command_no_callback() {
+  SensorManager& mgr = SensorManager::instance();
+  mgr.clear();
+  TvStateMachine sm(mgr, 1);
+  TEST_ASSERT_FALSE(sm.sendPowerCommand(true));
+}
+
+// ---------------------------------------------------------------------------
+// Disabled sensor does not contribute to confidence
+// ---------------------------------------------------------------------------
+void test_tv_sm_disabled_sensor_excluded() {
+  SensorManager& mgr = SensorManager::instance();
+  mgr.clear();
+  TvStateMachine sm(mgr, 1);
+
+  // Only disabled sensor → maxVotes=0 → confidence=0 → UNKNOWN
+  JsonDocument cfg = makeConfig(1, {{"s1", 5, false}});
+  sm.begin(cfg);
+
+  sm.onSensorUpdate("s1", true);
+  TEST_ASSERT_EQUAL(TvStateMachine::PowerState::UNKNOWN, sm.getPowerState());
+}
+
+// ---------------------------------------------------------------------------
+// SleepStateMachine: VERIFYING with TV ON → power-off fires
+// ---------------------------------------------------------------------------
+void test_sleep_sm_verifying_tv_on_fires_poweroff() {
+  // Use SleepStateMachine + TvStateMachine together
+  // TvStateMachine is in ON state; SleepSM should send power-off.
+  SensorManager& mgr = SensorManager::instance();
+  mgr.clear();
+  TvStateMachine tvSm(mgr, 1);
+
+  JsonDocument cfg = makeConfig(1, {{"s1", 5, true}});
+  tvSm.begin(cfg);
+  tvSm.onSensorUpdate("s1", true);  // TV is ON
+
+  // Now wire into SleepStateMachine
+  InsomniaTV::IClock* clkPtr = nullptr;
+  // Use a simple inline mock
+  class SimpleClock : public InsomniaTV::IClock {
+   public:
+    uint32_t nowMs() const override { return ms_; }
+    void advanceMs(uint32_t ms) override { ms_ += ms; }
+    uint32_t ms_ = 0;
+  } clk;
+
+  InsomniaTV::SleepStateMachine sleepSm(clk, 1000);
+  sleepSm.setTvStateMachine(&tvSm);
+
+  int powerOffCalls = 0;
+  sleepSm.setPowerOffCallback([&] { powerOffCalls++; });
+
+  clk.advanceMs(2000);
+  sleepSm.tick();          // MONITORING → RAMPING
+  sleepSm.onRampComplete(); // RAMPING → VERIFYING
+  sleepSm.tick();          // VERIFYING → POWERING_OFF → MONITORING
+
+  TEST_ASSERT_EQUAL(1, powerOffCalls);
+  TEST_ASSERT_EQUAL(InsomniaTV::State::MONITORING, sleepSm.getCurrentState());
+}
+
+// ---------------------------------------------------------------------------
+// SleepStateMachine: VERIFYING with TV already OFF → no power-off sent
+// ---------------------------------------------------------------------------
+void test_sleep_sm_verifying_tv_already_off() {
+  SensorManager& mgr = SensorManager::instance();
+  mgr.clear();
+  TvStateMachine tvSm(mgr, 1);
+
+  JsonDocument cfg = makeConfig(1, {{"s1", 5, true}});
+  tvSm.begin(cfg);
+  tvSm.onSensorUpdate("s1", false);  // TV is OFF
+
+  class SimpleClock : public InsomniaTV::IClock {
+   public:
+    uint32_t nowMs() const override { return ms_; }
+    void advanceMs(uint32_t ms) override { ms_ += ms; }
+    uint32_t ms_ = 0;
+  } clk;
+
+  InsomniaTV::SleepStateMachine sleepSm(clk, 1000);
+  sleepSm.setTvStateMachine(&tvSm);
+
+  int powerOffCalls = 0;
+  sleepSm.setPowerOffCallback([&] { powerOffCalls++; });
+
+  clk.advanceMs(2000);
+  sleepSm.tick();
+  sleepSm.onRampComplete();
+  sleepSm.tick();  // VERIFYING → TV already OFF → MONITORING, no power-off
+
+  TEST_ASSERT_EQUAL(0, powerOffCalls);
+  TEST_ASSERT_EQUAL(InsomniaTV::State::MONITORING, sleepSm.getCurrentState());
+}
+
+// ---------------------------------------------------------------------------
+// SleepStateMachine: VERIFYING with TV UNKNOWN → FALLBACK_OFF fires
+// ---------------------------------------------------------------------------
+void test_sleep_sm_verifying_tv_unknown_fallback() {
+  SensorManager& mgr = SensorManager::instance();
+  mgr.clear();
+  TvStateMachine tvSm(mgr, 99);  // hysteresis so high it stays UNKNOWN
+
+  JsonDocument cfg = makeConfig(99, {{"s1", 5, true}});
+  tvSm.begin(cfg);
+
+  class SimpleClock : public InsomniaTV::IClock {
+   public:
+    uint32_t nowMs() const override { return ms_; }
+    void advanceMs(uint32_t ms) override { ms_ += ms; }
+    uint32_t ms_ = 0;
+  } clk;
+
+  InsomniaTV::SleepStateMachine sleepSm(clk, 1000);
+  sleepSm.setTvStateMachine(&tvSm);
+
+  int powerOffCalls = 0;
+  sleepSm.setPowerOffCallback([&] { powerOffCalls++; });
+
+  clk.advanceMs(2000);
+  sleepSm.tick();
+  sleepSm.onRampComplete();
+  sleepSm.tick();  // VERIFYING → UNKNOWN → FALLBACK_OFF → fires callback
+
+  TEST_ASSERT_EQUAL(1, powerOffCalls);
+  TEST_ASSERT_EQUAL(InsomniaTV::State::MONITORING, sleepSm.getCurrentState());
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+int main() {
+  UNITY_BEGIN();
+  RUN_TEST(test_tv_sm_initial_state);
+  RUN_TEST(test_tv_sm_single_sensor_on);
+  RUN_TEST(test_tv_sm_single_sensor_off);
+  RUN_TEST(test_tv_sm_weighted_fusion_on_wins);
+  RUN_TEST(test_tv_sm_balanced_sensors_unknown);
+  RUN_TEST(test_tv_sm_hysteresis_prevents_flapping);
+  RUN_TEST(test_tv_sm_subscriber_callback);
+  RUN_TEST(test_tv_sm_get_contributions);
+  RUN_TEST(test_tv_sm_send_power_command);
+  RUN_TEST(test_tv_sm_send_power_command_no_callback);
+  RUN_TEST(test_tv_sm_disabled_sensor_excluded);
+  RUN_TEST(test_sleep_sm_verifying_tv_on_fires_poweroff);
+  RUN_TEST(test_sleep_sm_verifying_tv_already_off);
+  RUN_TEST(test_sleep_sm_verifying_tv_unknown_fallback);
+  return UNITY_END();
+}

--- a/test/test_web/test_web.cpp
+++ b/test/test_web/test_web.cpp
@@ -19,7 +19,8 @@ static std::string projectRoot() {
 // Returns true if any are found.
 static bool hasCurlyQuotes(const std::string& filePath) {
   std::ifstream f(filePath, std::ios::binary);
-  if (!f.is_open()) return false;
+  if (!f.is_open())
+    return false;
   uint8_t b0 = 0, b1 = 0;
   char ch;
   while (f.get(ch)) {

--- a/test/test_web/test_web.cpp
+++ b/test/test_web/test_web.cpp
@@ -1,0 +1,58 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#include <unity.h>
+
+#include <cstdint>
+#include <fstream>
+#include <string>
+
+// Returns the project root by stripping everything from "/test/" in __FILE__.
+static std::string projectRoot() {
+  std::string path(__FILE__);
+  auto pos = path.rfind("/test/");
+  return (pos != std::string::npos) ? path.substr(0, pos) : ".";
+}
+
+// Scans a binary file for UTF-8 curly/smart quote sequences:
+//   U+201C (left ")  = 0xE2 0x80 0x9C
+//   U+201D (right ") = 0xE2 0x80 0x9D
+// Returns true if any are found.
+static bool hasCurlyQuotes(const std::string& filePath) {
+  std::ifstream f(filePath, std::ios::binary);
+  if (!f.is_open()) return false;
+  uint8_t b0 = 0, b1 = 0;
+  char ch;
+  while (f.get(ch)) {
+    uint8_t b2 = static_cast<uint8_t>(ch);
+    if (b0 == 0xE2 && b1 == 0x80 && (b2 == 0x9C || b2 == 0x9D)) {
+      return true;
+    }
+    b0 = b1;
+    b1 = b2;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Curly/smart quotes (U+201C/U+201D) inside JS string literals embedded in
+// C++ raw strings silently break HTML attribute parsing in the browser.
+// This test catches the regression before it reaches firmware.
+// ---------------------------------------------------------------------------
+void test_webserver_no_curly_quotes() {
+  std::string path = projectRoot() + "/src/web/WebServer.cpp";
+  std::ifstream probe(path, std::ios::binary);
+  TEST_ASSERT_TRUE_MESSAGE(probe.is_open(),
+                           "Cannot open src/web/WebServer.cpp for inspection");
+  probe.close();
+
+  TEST_ASSERT_FALSE_MESSAGE(
+      hasCurlyQuotes(path),
+      "Curly/smart quotes (U+201C/U+201D) found in WebServer.cpp "
+      "-- they corrupt HTML attribute values in embedded JS strings");
+}
+
+int main() {
+  UNITY_BEGIN();
+  RUN_TEST(test_webserver_no_curly_quotes);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- **Sensor Framework** (`src/sensors/`): 5 sensor types (GPIO input/analog, ping, HTTP, UPnP) with `SensorManager` singleton registry, factory pattern, and thread-safe tick/subscribe
- **TvStateMachine** (`src/tv/`): determines TV power state by fusing multiple sensor readings with weighted votes; confidence scaled to [-10,+10]; configurable hysteresis prevents flapping; subscriber callbacks on state transitions (closes #37, #38)
- **SleepStateMachine**: full state transitions implemented using `IClock&` for testable time tracking; wired to `TvStateMachine` for VERIFYING state — TV already OFF skips power-off, UNKNOWN triggers FALLBACK_OFF
- **SensorManager**: `subscribeValueChange()` added; `tick()` notifies outside the lock (deadlock-safe)
- **Web UI**: sensor management tab with dynamic forms, scan button, live test action
- **Config persistence**: `saveConfig()` writes to LittleFS
- **OTA**: `esp32c3-ota` environment + `huge_app.csv` partition table
- **Build fix**: restore `INSOMNIATV_VERSION` CPPDEFINE broken by cache-fix commit

## Sensor Fusion Algorithm
Each detection sensor casts a weighted vote:
- `vote = weight × (+1 if ON, -1 if OFF)`
- `confidence = Σvotes / Σweights × 10` → range [-10, +10]
- `> +3` → ON, `< -3` → OFF, else UNKNOWN
- N consecutive consistent readings required before state commits (hysteresis)

## Test plan
- [ ] CI: lint + unit-tests + build all pass
- [ ] `test_sensors`: registry, lifecycle, state, all sensor types
- [ ] `test_tv`: fusion algorithm, hysteresis, subscriber callbacks, contributions, power command, SleepSM integration (TV ON/OFF/UNKNOWN paths)
- [ ] `test_state`: inactivity timeout → RAMPING, ramp complete → VERIFYING, IR activity cancellation
- [ ] OTA flash verified on device at 192.168.2.108 ✅

## Related
- Closes #37 (Sensor Framework unified state machine)
- Closes #38 (TvStateMachine power detection)
- Ref #39 (SSDP announcer — follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)