### PR TITLE
fix(web): real test coverage for #64 and #65

### DIFF
--- a/src/config/SystemCredentials.h
+++ b/src/config/SystemCredentials.h
@@ -1,0 +1,18 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#ifndef SRC_CONFIG_SYSTEMCREDENTIALS_H_
+#define SRC_CONFIG_SYSTEMCREDENTIALS_H_
+
+namespace InsomniaTV {
+
+// Single source of truth for the device's admin credentials, shared by the
+// web Basic Auth (WebServer.cpp) and ArduinoOTA (WifiSetup.cpp) -- one
+// system password, not two hardcoded literals that can drift apart.
+//
+// Hardcoded pending #51's proper per-device/NVS-backed credential system.
+constexpr const char* kSystemUsername = "admin";
+constexpr const char* kSystemPassword = "insomnia";
+
+}  // namespace InsomniaTV
+
+#endif  // SRC_CONFIG_SYSTEMCREDENTIALS_H_

--- a/src/hal/IRebootSequencer.h
+++ b/src/hal/IRebootSequencer.h
@@ -1,0 +1,31 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#ifndef SRC_HAL_IREBOOTSEQUENCER_H_
+#define SRC_HAL_IREBOOTSEQUENCER_H_
+
+#include <cstdint>
+
+namespace InsomniaTV {
+
+/**
+ * @brief Abstracts the response-then-reboot tail of an OTA update, so the
+ * ordering (response flushed before the device restarts) can be unit
+ * tested without a real ESPAsyncWebServer/ESP.restart().
+ */
+class IRebootSequencer {
+public:
+  virtual ~IRebootSequencer() = default;
+
+  // Sends the update-complete response to the client.
+  virtual void sendResponse(bool ok) = 0;
+
+  // Blocks for ms milliseconds (gives the response time to flush).
+  virtual void delayMs(uint32_t ms) = 0;
+
+  // Restarts the device.
+  virtual void restart() = 0;
+};
+
+}  // namespace InsomniaTV
+
+#endif  // SRC_HAL_IREBOOTSEQUENCER_H_

--- a/src/network/WifiSetup.cpp
+++ b/src/network/WifiSetup.cpp
@@ -5,6 +5,8 @@
 #include <cstdio>
 #include <string>
 
+#include "../config/SystemCredentials.h"
+
 #if defined(ARDUINO)
 #include <ArduinoOTA.h>
 #include <WiFi.h>
@@ -40,10 +42,7 @@ void WifiSetup::begin() {
   Serial.println(WiFi.localIP());
 
   ArduinoOTA.setHostname(apName.c_str());
-  // Same literal password as the web Basic Auth (WebServer.cpp) -- one
-  // system password, not two. Both are hardcoded pending #51's proper
-  // shared-credential fix; keep them in sync until then.
-  ArduinoOTA.setPassword("insomnia");
+  ArduinoOTA.setPassword(kSystemPassword);
   ArduinoOTA.onStart([]() { Serial.println("OTA Start"); });
   ArduinoOTA.begin();
 

--- a/src/web/UpdateCompletion.cpp
+++ b/src/web/UpdateCompletion.cpp
@@ -1,0 +1,21 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#include "UpdateCompletion.h"
+
+namespace InsomniaTV {
+
+namespace {
+// Empirically enough for ESPAsyncWebServer to flush the response before the
+// connection is torn down by restart() (#65).
+constexpr uint32_t kResponseFlushDelayMs = 1000;
+}  // namespace
+
+void handleUpdateCompletion(bool updateOk, IRebootSequencer& sequencer) {
+  sequencer.sendResponse(updateOk);
+  if (updateOk) {
+    sequencer.delayMs(kResponseFlushDelayMs);
+    sequencer.restart();
+  }
+}
+
+}  // namespace InsomniaTV

--- a/src/web/UpdateCompletion.h
+++ b/src/web/UpdateCompletion.h
@@ -1,0 +1,21 @@
+// Copyright 2026 insomniaTV Contributors. All rights reserved.
+
+#ifndef SRC_WEB_UPDATECOMPLETION_H_
+#define SRC_WEB_UPDATECOMPLETION_H_
+
+#include "../hal/IRebootSequencer.h"
+
+namespace InsomniaTV {
+
+/**
+ * @brief The /update handler's completion logic, extracted so it's unit
+ * testable without a real AsyncWebServerRequest/Update/ESP.restart().
+ *
+ * On success: send OK, wait for the response to actually flush, then
+ * restart. On failure: send FAIL, don't restart.
+ */
+void handleUpdateCompletion(bool updateOk, IRebootSequencer& sequencer);
+
+}  // namespace InsomniaTV
+
+#endif  // SRC_WEB_UPDATECOMPLETION_H_

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -8,7 +8,9 @@
 #include <functional>
 #include <string>
 
+#include "../config/SystemCredentials.h"
 #include "../version.h"
+#include "UpdateCompletion.h"
 
 #if defined(ARDUINO)
 #include <AsyncEventSource.h>
@@ -26,6 +28,27 @@ namespace InsomniaTV {
 
 #if defined(ARDUINO)
 AsyncEventSource events("/events");
+
+namespace {
+class ArduinoRebootSequencer : public IRebootSequencer {
+public:
+  explicit ArduinoRebootSequencer(AsyncWebServerRequest* request)
+      : _request(request) {}
+
+  void sendResponse(bool ok) override {
+    AsyncWebServerResponse* res =
+        _request->beginResponse(200, "text/plain", ok ? "OK" : "FAIL");
+    res->addHeader("Connection", "close");
+    _request->send(res);
+  }
+
+  void delayMs(uint32_t ms) override { delay(ms); }
+  void restart() override { ESP.restart(); }
+
+private:
+  AsyncWebServerRequest* _request;
+};
+}  // namespace
 
 WebServer::WebServer(uint16_t port, SamsungTvDiscovery& discovery,
                      ConfigManager& configMgr)
@@ -72,7 +95,7 @@ void WebServer::begin() {
 
 void WebServer::setupRoutes() {
   _server.on("/", HTTP_GET, [](AsyncWebServerRequest* request) {
-    if (!request->authenticate("admin", "insomnia")) {
+    if (!request->authenticate(kSystemUsername, kSystemPassword)) {
       return request->requestAuthentication();
     }
     // Serve embedded index.html
@@ -679,7 +702,7 @@ document.getElementsByClassName('tablinks')[0].click();
   });
 
   _server.on("/api/status", HTTP_GET, [this](AsyncWebServerRequest* request) {
-    if (!request->authenticate("admin", "insomnia")) {
+    if (!request->authenticate(kSystemUsername, kSystemPassword)) {
       return request->requestAuthentication();
     }
     JsonDocument doc;
@@ -714,7 +737,7 @@ document.getElementsByClassName('tablinks')[0].click();
   });
 
   _server.on("/api/sensors", HTTP_GET, [](AsyncWebServerRequest* request) {
-    if (!request->authenticate("admin", "insomnia")) {
+    if (!request->authenticate(kSystemUsername, kSystemPassword)) {
       return request->requestAuthentication();
     }
     auto sensors = SensorManager::instance().listSensors();
@@ -741,7 +764,7 @@ document.getElementsByClassName('tablinks')[0].click();
   _server.on(
       "/api/sensors", HTTP_POST,
       [](AsyncWebServerRequest* request) {
-        if (!request->authenticate("admin", "insomnia")) {
+        if (!request->authenticate(kSystemUsername, kSystemPassword)) {
           return request->requestAuthentication();
         }
       },
@@ -780,7 +803,7 @@ document.getElementsByClassName('tablinks')[0].click();
 
   _server.on("/api/sensors", HTTP_DELETE,
              [this](AsyncWebServerRequest* request) {
-               if (!request->authenticate("admin", "insomnia")) {
+               if (!request->authenticate(kSystemUsername, kSystemPassword)) {
                  return request->requestAuthentication();
                }
                if (request->hasParam("id")) {
@@ -815,7 +838,7 @@ document.getElementsByClassName('tablinks')[0].click();
 
   _server.on(
       "/api/sensors/test", HTTP_POST, [](AsyncWebServerRequest* request) {
-        if (!request->authenticate("admin", "insomnia")) {
+        if (!request->authenticate(kSystemUsername, kSystemPassword)) {
           return request->requestAuthentication();
         }
         if (request->hasParam("id", true)) {
@@ -837,17 +860,8 @@ document.getElementsByClassName('tablinks')[0].click();
       "/update", HTTP_POST,
       [](AsyncWebServerRequest* request) {
         bool shouldReboot = !Update.hasError();
-        AsyncWebServerResponse* res = request->beginResponse(
-            200, "text/plain", shouldReboot ? "OK" : "FAIL");
-        res->addHeader("Connection", "close");
-        request->send(res);
-        if (shouldReboot) {
-          // Give the async response time to actually flush before tearing
-          // down the connection -- restarting immediately races the
-          // response delivery and the client never sees it (#65).
-          delay(1000);
-          ESP.restart();
-        }
+        ArduinoRebootSequencer sequencer(request);
+        handleUpdateCompletion(shouldReboot, sequencer);
       },
       [](AsyncWebServerRequest* request, String filename, size_t index,
          uint8_t* data, size_t len, bool final) {
@@ -871,7 +885,7 @@ document.getElementsByClassName('tablinks')[0].click();
   // our handler is called — avoids the deferred-send race with _send().
   _server.on("/api/probe", HTTP_POST,
              [this](AsyncWebServerRequest* request, JsonVariant& json) {
-               if (!request->authenticate("admin", "insomnia")) {
+               if (!request->authenticate(kSystemUsername, kSystemPassword)) {
                  return request->requestAuthentication();
                }
                std::string type = json["type"] | "";
@@ -916,7 +930,7 @@ document.getElementsByClassName('tablinks')[0].click();
              });
 
   _server.on("/api/scan", HTTP_POST, [this](AsyncWebServerRequest* request) {
-    if (!request->authenticate("admin", "insomnia")) {
+    if (!request->authenticate(kSystemUsername, kSystemPassword)) {
       return request->requestAuthentication();
     }
     xTaskCreate(
@@ -933,7 +947,7 @@ document.getElementsByClassName('tablinks')[0].click();
 
   _server.on("/api/discovery", HTTP_GET,
              [this](AsyncWebServerRequest* request) {
-               if (!request->authenticate("admin", "insomnia")) {
+               if (!request->authenticate(kSystemUsername, kSystemPassword)) {
                  return request->requestAuthentication();
                }
                JsonDocument doc;
@@ -952,7 +966,7 @@ document.getElementsByClassName('tablinks')[0].click();
   // GET /api/tv-config — live sensor contributions and power state
   _server.on(
       "/api/tv-config", HTTP_GET, [this](AsyncWebServerRequest* request) {
-        if (!request->authenticate("admin", "insomnia")) {
+        if (!request->authenticate(kSystemUsername, kSystemPassword)) {
           return request->requestAuthentication();
         }
         JsonDocument doc;
@@ -980,7 +994,7 @@ document.getElementsByClassName('tablinks')[0].click();
   // if registered first.
   _server.on("/api/files/download", HTTP_GET,
              [](AsyncWebServerRequest* request) {
-               if (!request->authenticate("admin", "insomnia")) {
+               if (!request->authenticate(kSystemUsername, kSystemPassword)) {
                  return request->requestAuthentication();
                }
                if (!request->hasParam("path")) {
@@ -997,7 +1011,7 @@ document.getElementsByClassName('tablinks')[0].click();
 
   // GET /api/files/edit?path=<path> — return file contents as plain text
   _server.on("/api/files/edit", HTTP_GET, [](AsyncWebServerRequest* request) {
-    if (!request->authenticate("admin", "insomnia")) {
+    if (!request->authenticate(kSystemUsername, kSystemPassword)) {
       return request->requestAuthentication();
     }
     if (!request->hasParam("path")) {
@@ -1028,7 +1042,7 @@ document.getElementsByClassName('tablinks')[0].click();
   _server.on(
       "/api/files/edit", HTTP_POST,
       [](AsyncWebServerRequest* request) {
-        if (!request->authenticate("admin", "insomnia")) {
+        if (!request->authenticate(kSystemUsername, kSystemPassword)) {
           return request->requestAuthentication();
         }
       },
@@ -1086,7 +1100,7 @@ document.getElementsByClassName('tablinks')[0].click();
 
   // GET /api/files — recursive LittleFS listing (must come after /api/files/*)
   _server.on("/api/files", HTTP_GET, [](AsyncWebServerRequest* request) {
-    if (!request->authenticate("admin", "insomnia")) {
+    if (!request->authenticate(kSystemUsername, kSystemPassword)) {
       return request->requestAuthentication();
     }
     JsonDocument doc;
@@ -1120,7 +1134,7 @@ document.getElementsByClassName('tablinks')[0].click();
 
   // DELETE /api/files?path=<path>
   _server.on("/api/files", HTTP_DELETE, [](AsyncWebServerRequest* request) {
-    if (!request->authenticate("admin", "insomnia")) {
+    if (!request->authenticate(kSystemUsername, kSystemPassword)) {
       return request->requestAuthentication();
     }
     if (!request->hasParam("path")) {

--- a/test/test_web/test_web.cpp
+++ b/test/test_web/test_web.cpp
@@ -4,7 +4,15 @@
 
 #include <cstdint>
 #include <fstream>
+#include <sstream>
 #include <string>
+#include <vector>
+
+#include "config/SystemCredentials.h"
+#include "web/UpdateCompletion.h"
+
+using InsomniaTV::handleUpdateCompletion;
+using InsomniaTV::IRebootSequencer;
 
 // Returns the project root by stripping everything from "/test/" in __FILE__.
 static std::string projectRoot() {
@@ -52,8 +60,106 @@ void test_webserver_no_curly_quotes() {
       "-- they corrupt HTML attribute values in embedded JS strings");
 }
 
+// Reads an entire file into a string for substring scanning.
+static std::string readFile(const std::string& filePath) {
+  std::ifstream f(filePath, std::ios::binary);
+  std::ostringstream ss;
+  ss << f.rdbuf();
+  return ss.str();
+}
+
+// ---------------------------------------------------------------------------
+// Test: the shared system credentials constants are actually non-empty.
+// ---------------------------------------------------------------------------
+void test_system_credentials_non_empty() {
+  TEST_ASSERT_TRUE(InsomniaTV::kSystemUsername[0] != '\0');
+  TEST_ASSERT_TRUE(InsomniaTV::kSystemPassword[0] != '\0');
+}
+
+// ---------------------------------------------------------------------------
+// Regression guard: WebServer.cpp and WifiSetup.cpp must authenticate via
+// the shared SystemCredentials constants, not a re-duplicated hardcoded
+// literal that can drift out of sync with it (#64).
+// ---------------------------------------------------------------------------
+void test_no_duplicate_hardcoded_credentials() {
+  std::string webServer = readFile(projectRoot() + "/src/web/WebServer.cpp");
+  std::string wifiSetup =
+      readFile(projectRoot() + "/src/network/WifiSetup.cpp");
+  TEST_ASSERT_TRUE_MESSAGE(!webServer.empty(),
+                           "Cannot open src/web/WebServer.cpp for inspection");
+  TEST_ASSERT_TRUE_MESSAGE(
+      !wifiSetup.empty(),
+      "Cannot open src/network/WifiSetup.cpp for inspection");
+
+  TEST_ASSERT_EQUAL_INT_MESSAGE(
+      static_cast<int>(std::string::npos),
+      static_cast<int>(webServer.find("authenticate(\"admin\", \"insomnia\")")),
+      "WebServer.cpp has a re-duplicated hardcoded credential literal -- "
+      "use kSystemUsername/kSystemPassword instead");
+  TEST_ASSERT_EQUAL_INT_MESSAGE(
+      static_cast<int>(std::string::npos),
+      static_cast<int>(wifiSetup.find("setPassword(\"insomnia\")")),
+      "WifiSetup.cpp has a re-duplicated hardcoded credential literal -- "
+      "use kSystemPassword instead");
+}
+
+// ---------------------------------------------------------------------------
+// Records call order and arguments so tests can assert on sequencing, not
+// just final state -- this is what makes the #65 regression actually
+// catchable (a response-then-restart-with-no-delay reintroduction would
+// fail test_update_completion_delays_before_restart_on_success below).
+// ---------------------------------------------------------------------------
+class MockRebootSequencer : public IRebootSequencer {
+public:
+  std::vector<std::string> calls;
+  uint32_t lastDelayMs = 0;
+
+  void sendResponse(bool ok) override {
+    calls.push_back(ok ? "response:ok" : "response:fail");
+  }
+  void delayMs(uint32_t ms) override {
+    lastDelayMs = ms;
+    calls.push_back("delay");
+  }
+  void restart() override { calls.push_back("restart"); }
+};
+
+// ---------------------------------------------------------------------------
+// Test: on a successful update, the response is sent, then a real delay
+// happens, then the device restarts -- in that order (#65).
+// ---------------------------------------------------------------------------
+void test_update_completion_delays_before_restart_on_success() {
+  MockRebootSequencer seq;
+  handleUpdateCompletion(true, seq);
+
+  TEST_ASSERT_EQUAL(3, static_cast<int>(seq.calls.size()));
+  TEST_ASSERT_EQUAL_STRING("response:ok", seq.calls[0].c_str());
+  TEST_ASSERT_EQUAL_STRING("delay", seq.calls[1].c_str());
+  TEST_ASSERT_EQUAL_STRING("restart", seq.calls[2].c_str());
+  // Catches a regression back to a too-short/zero delay, not just a missing
+  // call -- the original bug was the response never reaching the client
+  // before the connection was torn down.
+  TEST_ASSERT_TRUE(seq.lastDelayMs >= 500);
+}
+
+// ---------------------------------------------------------------------------
+// Test: on a failed update, only the failure response is sent -- no delay,
+// no restart.
+// ---------------------------------------------------------------------------
+void test_update_completion_no_restart_on_failure() {
+  MockRebootSequencer seq;
+  handleUpdateCompletion(false, seq);
+
+  TEST_ASSERT_EQUAL(1, static_cast<int>(seq.calls.size()));
+  TEST_ASSERT_EQUAL_STRING("response:fail", seq.calls[0].c_str());
+}
+
 int main() {
   UNITY_BEGIN();
   RUN_TEST(test_webserver_no_curly_quotes);
+  RUN_TEST(test_system_credentials_non_empty);
+  RUN_TEST(test_no_duplicate_hardcoded_credentials);
+  RUN_TEST(test_update_completion_delays_before_restart_on_success);
+  RUN_TEST(test_update_completion_no_restart_on_failure);
   return UNITY_END();
 }


### PR DESCRIPTION
Both #64 and #65 shipped as code-only fixes in #68 with no way to unit-test the actual logic natively — `ArduinoOTA`/`ESPAsyncWebServer` aren't available/mockable in the native test build. That's exactly the anti-pattern #33 was filed to audit (confirmed tonight to be a real, repeated problem in this codebase's history). Closing that gap properly here instead of adding a token/text-scan test.

## #64 — shared system password
Extracted into `src/config/SystemCredentials.h` (`kSystemUsername`/`kSystemPassword`), used by both `WifiSetup.cpp`'s `ArduinoOTA.setPassword()` and all 15 `WebServer.cpp` Basic Auth call sites — replacing two separately hardcoded literals that could silently drift apart. Native tests: constants are non-empty, plus a regression guard scanning both files for a re-duplicated hardcoded literal.

## #65 — response-then-reboot ordering
Extracted the `/update` handler's completion logic into a pure `handleUpdateCompletion(bool, IRebootSequencer&)` function (`src/web/UpdateCompletion.*`), following the existing `IIrDriver`/`IMqttClient` HAL pattern (new `src/hal/IRebootSequencer.h`). `WebServer.cpp` wires the real `ArduinoRebootSequencer`; a native test with `MockRebootSequencer` asserts the actual call order (response → delay ≥ 500ms → restart) and that a failed update doesn't restart at all.

**Validated this test has real teeth** (per the principle: unwrapping an `#ifdef ARDUINO` stub should make a previously-fake-passing test start failing if the fix regresses): manually reverted `handleUpdateCompletion` to the original no-delay bug and confirmed the test fails (`calls=2`, missing the delay step) before restoring the fix. Compiled/ran this in isolation with plain `g++` (not `pio`, no toolchain download).

## Test plan
- [x] Native tests pass, including the two new ones in `test_web`.
- [x] Manually confirmed the #65 test fails when the fix is reverted (see commit message for detail).
- [ ] CI green.