### PR TITLE
fix(sensors): move blocking sensor I/O off the request/loop hot path

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,6 +81,16 @@ void statusLedTask(void*) {
   }
 }
 
+// Sensor reads (ping/http) can block for seconds on an unreachable target.
+// Runs on its own task so that doesn't stall loop()'s RampScheduler/
+// SleepStateMachine ticking or IR polling (#75).
+void sensorPollTask(void*) {
+  for (;;) {
+    InsomniaTV::SensorManager::instance().tick();
+    vTaskDelay(pdMS_TO_TICKS(1000));
+  }
+}
+
 void setup() {
   // Lower power draw (less heat through the onboard 5V regulator); this
   // workload is nowhere near CPU-bound.
@@ -98,6 +108,7 @@ void setup() {
   ledcAttach(STATUS_LED_PIN, kStatusLedFreqHz, kStatusLedResolutionBits);
   ledcWrite(STATUS_LED_PIN, 255);  // start off
   xTaskCreate(statusLedTask, "status_led", 2048, NULL, 1, NULL);
+  xTaskCreate(sensorPollTask, "sensor_tick", 4096, NULL, 1, NULL);
 
   // Filesystem — must be mounted before any config or file-manager access
   if (!LittleFS.begin(true)) {
@@ -202,7 +213,6 @@ void setup() {
 
 void loop() {
   wifiSetup.handleResetButton();
-  InsomniaTV::SensorManager::instance().tick();
   if (sleepSm != nullptr) {
     sleepSm->tick();
   }

--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -155,4 +155,10 @@ void SensorManager::tick() {
   }
 }
 
+bool SensorManager::getCachedValue(const std::string& id) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = lastValues_.find(id);
+  return it != lastValues_.end() ? it->second : false;
+}
+
 }  // namespace InsomniaTV

--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -132,13 +132,30 @@ void SensorManager::init(const std::string& configJson,
 }
 
 void SensorManager::tick() {
+  // Snapshot the sensor list, then read outside the lock -- Sensor::read()
+  // can block for real seconds on an unreachable ping/http target, and
+  // holding mutex_ for that whole stretch would make getCachedValue() (used
+  // by /api/sensors, expected to be cheap and non-blocking) block right
+  // along with it, defeating the point of caching in the first place (#75).
+  std::vector<std::pair<std::string, std::shared_ptr<Sensor>>> snapshot;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    snapshot.assign(sensors_.begin(), sensors_.end());
+  }
+
+  std::vector<std::pair<std::string, bool>> reads;
+  reads.reserve(snapshot.size());
+  for (auto const& [id, sensor] : snapshot) {
+    bool value = sensor->read();
+    sensor->setState(value ? Sensor::State::READY : Sensor::State::ERROR);
+    reads.emplace_back(id, value);
+  }
+
   std::vector<std::pair<std::string, bool>> changes;
   std::vector<ValueChangeCallback> cbs;
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    for (auto const& [id, sensor] : sensors_) {
-      bool value = sensor->read();
-      sensor->setState(value ? Sensor::State::READY : Sensor::State::ERROR);
+    for (auto const& [id, value] : reads) {
       auto it = lastValues_.find(id);
       if (it == lastValues_.end() || it->second != value) {
         lastValues_[id] = value;

--- a/src/sensors/SensorManager.h
+++ b/src/sensors/SensorManager.h
@@ -54,6 +54,13 @@ public:
   void clear();
   void removeSensor(const std::string& id);
 
+  // Returns the last value tick() observed for this sensor, or false if it
+  // has never been read yet. Cheap and non-blocking -- callers that just
+  // want the current known state (e.g. the web API) should use this
+  // instead of calling Sensor::read() themselves, which can block for
+  // seconds on an unreachable ping/http target (#75).
+  bool getCachedValue(const std::string& id) const;
+
 private:
   SensorManager() = default;
   ~SensorManager() = default;

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -72,13 +72,14 @@ void WebServer::begin() {
   _server.addHandler(&events);
   _server.begin();
 
-  // Periodic sensor reader task
+  // Periodic sensor status broadcaster -- reads the cache SensorManager's
+  // own poll task maintains, doesn't read hardware itself (#75).
   xTaskCreate(
       [](void* pvParameters) {
         for (;;) {
           auto sensors = SensorManager::instance().listSensors();
           for (auto const& s : sensors) {
-            bool val = s->read();
+            bool val = SensorManager::instance().getCachedValue(s->getId());
             JsonDocument doc;
             doc["id"] = s->getId();
             doc["value"] = val;
@@ -748,7 +749,7 @@ document.getElementsByClassName('tablinks')[0].click();
       obj["id"] = sensor->getId();
       obj["type"] = sensor->getType();
       obj["available"] = sensor->isAvailable();
-      obj["value"] = sensor->read();
+      obj["value"] = SensorManager::instance().getCachedValue(sensor->getId());
       JsonDocument cfg = sensor->getConfig();
       for (JsonPair kv : cfg.as<JsonObject>()) {
         const char* k = kv.key().c_str();

--- a/test/test_sensors/test_sensors.cpp
+++ b/test/test_sensors/test_sensors.cpp
@@ -3,6 +3,7 @@
 #include <unity.h>
 
 #include <memory>
+#include <string>
 
 #include "../../src/sensors/GpioAnalogSensor.h"
 #include "../../src/sensors/GpioInputSensor.h"
@@ -85,6 +86,65 @@ void test_http_sensor() {
   TEST_ASSERT_EQUAL_STRING("http1", sensor.getId().c_str());
 }
 
+// ---------------------------------------------------------------------------
+// Controllable sensor for testing SensorManager's value cache directly,
+// without depending on any real sensor type's native-stub read() behavior.
+// ---------------------------------------------------------------------------
+class MockCacheSensor : public Sensor {
+public:
+  MockCacheSensor(const std::string& id, bool value)
+      : id_(id), value_(value) {
+    state_ = State::READY;
+  }
+  std::string getId() const override { return id_; }
+  std::string getType() const override { return "mock"; }
+  bool read() override { return value_; }
+  JsonDocument getConfig() override { return JsonDocument(); }
+  void setConfig(const JsonDocument&) override {}
+  void setValue(bool v) { value_ = v; }
+
+private:
+  std::string id_;
+  bool value_;
+};
+
+// ---------------------------------------------------------------------------
+// Test: getCachedValue() defaults to false for a sensor that's never been
+// tick()'d yet, and for an unknown id -- doesn't block, doesn't crash (#75).
+// ---------------------------------------------------------------------------
+void test_get_cached_value_defaults_false_when_never_read() {
+  auto& mgr = SensorManager::instance();
+  mgr.clear();
+  auto sensor = std::make_shared<MockCacheSensor>("cache_test", true);
+  mgr.registerSensor(sensor);
+
+  TEST_ASSERT_FALSE(mgr.getCachedValue("cache_test"));
+  TEST_ASSERT_FALSE(mgr.getCachedValue("nonexistent_id"));
+}
+
+// ---------------------------------------------------------------------------
+// Test: getCachedValue() reflects the value from the last tick(), not a
+// fresh live read -- this is exactly what lets /api/sensors and the SSE
+// poll task avoid blocking on hardware I/O themselves (#75).
+// ---------------------------------------------------------------------------
+void test_get_cached_value_reflects_last_tick() {
+  auto& mgr = SensorManager::instance();
+  mgr.clear();
+  auto sensor = std::make_shared<MockCacheSensor>("cache_test2", true);
+  mgr.registerSensor(sensor);
+
+  mgr.tick();
+  TEST_ASSERT_TRUE(mgr.getCachedValue("cache_test2"));
+
+  sensor->setValue(false);
+  TEST_ASSERT_TRUE_MESSAGE(
+      mgr.getCachedValue("cache_test2"),
+      "cache should still show the old value before the next tick()");
+
+  mgr.tick();
+  TEST_ASSERT_FALSE(mgr.getCachedValue("cache_test2"));
+}
+
 int main() {
   UNITY_BEGIN();
   RUN_TEST(test_sensor_manager_registry);
@@ -94,5 +154,7 @@ int main() {
   RUN_TEST(test_gpio_analog_sensor);
   RUN_TEST(test_ping_sensor);
   RUN_TEST(test_http_sensor);
+  RUN_TEST(test_get_cached_value_defaults_false_when_never_read);
+  RUN_TEST(test_get_cached_value_reflects_last_tick);
   return UNITY_END();
 }

--- a/test/test_sensors/test_sensors.cpp
+++ b/test/test_sensors/test_sensors.cpp
@@ -92,8 +92,7 @@ void test_http_sensor() {
 // ---------------------------------------------------------------------------
 class MockCacheSensor : public Sensor {
 public:
-  MockCacheSensor(const std::string& id, bool value)
-      : id_(id), value_(value) {
+  MockCacheSensor(const std::string& id, bool value) : id_(id), value_(value) {
     state_ = State::READY;
   }
   std::string getId() const override { return id_; }


### PR DESCRIPTION
Fixes #75, live-reproduced tonight: \`GET /api/sensors\` didn't respond even after 32s. Root cause was sensor reads happening in three separate places, each blocking independently: main \`loop()\`'s \`SensorManager::tick()\`, \`WebServer\`'s own periodic SSE-poll task, and \`/api/sensors\`'s handler itself calling \`sensor->read()\` directly. Several sensor types block for real durations against an unreachable target (\`HttpSensor\` up to 5s, \`PingSensor\` up to 1s each) — with 5 sensors configured, worst case stacks well past what a web request should ever wait on.

## Fix
- \`SensorManager::tick()\` moves to its own dedicated task (\`sensorPollTask\`, 1s interval), decoupling sensor I/O from \`loop()\`'s \`RampScheduler\`/\`SleepStateMachine\` ticking and IR polling (#63).
- Added \`SensorManager::getCachedValue()\`, exposing the value cache \`tick()\` already maintained internally but never shared with anything else.
- \`/api/sensors\` and \`WebServer\`'s SSE poll task now read the cache instead of calling \`sensor->read()\` themselves. \`/api/sensors/test\` (an explicit user-initiated "test this sensor now" button) is left as a live read on purpose — that's the one place blocking is actually the intent.

## Also investigated, not fixed here
\`PingSensor\`'s \`timeout_ms\` config field is loaded/saved but never actually passed to the underlying ping call — turns out the \`ESP32Ping\` library's public API has no timeout parameter at all. The lower-level API that does support one is callback-based/async, and using it properly needs a bigger rewrite I don't want to rush without careful hardware iteration (a wrong implementation risks hanging instead of timing out). Filed as #76.

## Test plan
- [x] Native tests: two new ones in \`test_sensors\` covering \`getCachedValue()\`'s default-false and reflects-last-tick behavior, using a small controllable mock sensor (existing real sensor types are ARDUINO-stubbed to always return false natively, so they can't exercise this).
- [ ] CI green.
- [ ] Flash to hardware, confirm \`/api/sensors\` responds quickly even with the currently-configured unreachable-ish sensors.